### PR TITLE
Add preview with Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+source

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM ruby:2.3.1-onbuild
+VOLUME /usr/src/app/source
+EXPOSE 4567
+
+RUN apt-get update && apt-get install -y nodejs \
+&& apt-get clean && rm -rf /var/lib/apt/lists/*
+
+CMD ["bundle", "exec", "middleman", "server", "--watcher-force-polling"]

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ bundle exec middleman server
 
 # OR run this to run with vagrant
 vagrant up
+
+# OR with docker
+docker-compose up
 ```
 
 You can now see the docs at ```http://localhost:4567```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+app:
+  build: .
+  ports:
+   - 4567:4567
+  volumes:
+   - ./source:/usr/src/app/source


### PR DESCRIPTION
Neither the vagrant not the bundle methods seem to work for me. But the docker one works.

Why only limit yourself to two universal standards when you can have three?