### PR TITLE
Fix inconsistencies

### DIFF
--- a/source/includes/_flights_browseView.md
+++ b/source/includes/_flights_browseView.md
@@ -212,7 +212,7 @@ Will search only for direct flights if the value is true
 
 ### rtn
 
-Trip type: 0 if oneway or 1 if return or multicity trip
+Trip type: 0 if oneway or 1 if return trip
 
 `rtn`
 

--- a/source/includes/_flights_browse_dates.md
+++ b/source/includes/_flights_browse_dates.md
@@ -147,7 +147,7 @@ The following tables show the level of precision supported for the origin and de
 | Parameter | Description |
 | --- | --- |
 | `Dates`| The list of outbound and inbound dates for which quotes are available. |
-| ```Quotes``` | Contains the list of markets (array of countries as name-value pairs). |
-| ```Places``` | Contains the list of markets (array of countries as name-value pairs). |
-| ```Carriers``` | Contains the list of markets (array of countries as name-value pairs). |
-| ```Currencies``` | Contains the list of markets (array of countries as name-value pairs). |
+| ```Quotes``` | The list of quotes specified in the list of Dates. |
+| ```Places``` | The list of places matching the search results. |
+| ```Carriers``` | The list of carriers specified in the list of quotes. |
+| ```Currencies``` | The currency of the quote prices. |

--- a/source/includes/_flights_browse_grid.md
+++ b/source/includes/_flights_browse_grid.md
@@ -107,8 +107,8 @@ The following tables show the level of precision supported for the origin and de
 
 | Parameter | Description |
 | --- | --- |
-| ```Dates``` | Matrix of all the dates available with associated price. |
-| ```Places``` | Contains the list of markets (array of countries as name-value pairs). |
-| ```Carriers``` | Contains the list of markets (array of countries as name-value pairs). |
-| ```Currencies``` | Contains the list of markets (array of countries as name-value pairs). |
+| ```Dates``` | Matrix of all the dates available with associated prices. |
+| ```Places``` | The list of places matching the search results. |
+| ```Carriers``` | The list of carriers specified in the list of quotes. |
+| ```Currencies``` | The currency of the quote prices. |
 

--- a/source/includes/_flights_browse_quotes.md
+++ b/source/includes/_flights_browse_quotes.md
@@ -120,8 +120,8 @@ The following tables show the level of precision supported for the origin and de
 
 | Parameter | Description |
 | --- | --- |
-| ```Quotes``` | Contains the list of markets (array of countries as name-value pairs). |
-| ```Places``` | Contains the list of markets (array of countries as name-value pairs). |
-| ```Carriers``` | Contains the list of markets (array of countries as name-value pairs). |
-| ```Currencies``` | Contains the list of markets (array of countries as name-value pairs). |
+| ```Quotes``` | Contains the list of cheapest quotes available for the search. |
+| ```Places``` | The list of places matching the search results. |
+| ```Carriers``` | The list of carriers specified in the list of quotes. |
+| ```Currencies``` | The currency of the quote prices. |
 

--- a/source/includes/_flights_browse_routes.md
+++ b/source/includes/_flights_browse_routes.md
@@ -138,9 +138,9 @@ The following tables show the level of precision supported for the origin and de
 
 | Parameter | Description |
 | --- | --- |
-| `Routes`| Contains the list of routes available, assembled from the individual quotes. |
-| ```Quotes``` | Contains the list of markets (array of countries as name-value pairs). |
-| ```Places``` | Contains the list of markets (array of countries as name-value pairs). |
-| ```Carriers``` | Contains the list of markets (array of countries as name-value pairs). |
-| ```Currencies``` | Contains the list of markets (array of countries as name-value pairs). |
+| ```Routes``` | Contains the list of routes available, assembled from the individual quotes. |
+| ```Quotes``` | The list of quotes specified in the list of routes. |
+| ```Places``` | The list of places specified in the list of routes. |
+| ```Carriers``` | The list of carriers specified in the list of quotes. |
+| ```Currencies``` | The currency of the quote prices. |
 

--- a/source/includes/_flights_calendarMonthView.md
+++ b/source/includes/_flights_calendarMonthView.md
@@ -182,7 +182,7 @@ Will search only for direct flights if the value is true
 
 ### rtn
 
-Trip type: 0 if oneway or 1 if return or multicity trip
+Trip type: 0 if oneway or 1 if return trip
 
 `rtn`
 

--- a/source/includes/_places.md
+++ b/source/includes/_places.md
@@ -33,7 +33,7 @@ GET "https://partners.api.skyscanner.net/apiservices/
 ```
 *API endpoint*
 
-`GET /autosuggest/v1.0/{market}/{currency}/{locale}`
+`GET /autosuggest/v1.0/{country}/{currency}/{locale}`
 
 *Try it out*
 
@@ -113,7 +113,7 @@ Get information about a country, city or airport using its ID.
 
 ```shell
 GET "https://partners.api.skyscanner.net/apiservices/
-    autosuggest/v1.0/{market}/{currency}/{locale}?
+    autosuggest/v1.0/{country}/{currency}/{locale}?
     id={place_id}&
     apiKey={apiKey}"
 ```


### PR DESCRIPTION
1. For autosuggest API endpoint, changed `market` to `country`. They mean the same thing so just going for consistency.
2. Added some (brief) descriptions of the Browse response params. They were all incorrectly described as "List of markets" before...
3. Removed multicity from Browse trip types as it is not supported.
