### PR TITLE
Add a notice about poll url

### DIFF
--- a/source/includes/_flights_live_prices.md
+++ b/source/includes/_flights_live_prices.md
@@ -111,7 +111,7 @@ Please refer to our <a href="#response-codes">response codes</a> in case of unsu
 curl "{URL returned in Creating the session Location header}?apiKey={apiKey}" -X GET
 ```
 
-Please use the URL returned in the Creating the session `Location` header
+Use the polling endpoint provided in the successful response of the create request.
 
 *API endpoint*
 
@@ -473,7 +473,7 @@ Please refer to our <a href="#response-codes">response codes</a> in case of unsu
 curl "{URL returned in Get booking details Location header}?apiKey={apiKey}" -X GET
 ```
 
-Please use the URL returned in the Get booking details `Location` header
+Use the polling endpoint provided in the successful response of the get booking details request.
 
 *API endpoint*
 

--- a/source/includes/_flights_live_prices.md
+++ b/source/includes/_flights_live_prices.md
@@ -79,7 +79,7 @@ or go to our [test harness](https://www.partners.skyscanner.net/flightsliveprici
 > Example response with polling url:
 
 ```shell
-Location "https://partners.api.skyscanner.net/apiservices/pricing/uk1/v1.0/
+Location "https://partners.api.skyscanner.net/apiservices/pricing/v1.0/
     {SessionKey}"
 ```
 
@@ -108,7 +108,7 @@ Please refer to our <a href="#response-codes">response codes</a> in case of unsu
 > Example request with polling url:
 
 ```shell
-Location "https://partners.api.skyscanner.net/apiservices/pricing/uk1/v1.0/
+Location "https://partners.api.skyscanner.net/apiservices/pricing/v1.0/
     {SessionKey}?apiKey={apiKey}
     &stops=0
     &duration=360
@@ -119,6 +119,9 @@ Location "https://partners.api.skyscanner.net/apiservices/pricing/uk1/v1.0/
 
 `GET /pricing/v1.0/{SessionKey}`
 
+<aside class="notice">
+  Please note that the actual polling endpoint will be provided in the successful response of the <a href="#creating-the-session">Create Request</a>.
+</aside>
 
 *TRY IT OUT*
 

--- a/source/includes/_flights_live_prices.md
+++ b/source/includes/_flights_live_prices.md
@@ -108,11 +108,7 @@ Please refer to our <a href="#response-codes">response codes</a> in case of unsu
 > Example request with polling url:
 
 ```shell
-Location "https://partners.api.skyscanner.net/apiservices/pricing/v1.0/
-    {SessionKey}?apiKey={apiKey}
-    &stops=0
-    &duration=360
-    &includeCarriers=ba;u2;af"
+curl "{URL returned in Creating the session Location header}?apiKey={apiKey}" -X GET
 ```
 
 *API endpoint*
@@ -120,7 +116,7 @@ Location "https://partners.api.skyscanner.net/apiservices/pricing/v1.0/
 `GET /pricing/v1.0/{SessionKey}`
 
 <aside class="notice">
-  Please note that the actual polling endpoint will be provided in the successful response of the <a href="#creating-the-session">Create Request</a>.
+  Please note that the actual polling endpoint will be provided in the successful response of the <a href="#creating-the-session">Creating the session</a> request.
 </aside>
 
 *TRY IT OUT*
@@ -420,6 +416,10 @@ The full URL and body content are provided in the response from the live pricing
 `PUT /pricing/v1.0/{SessionKey}/booking`
 
 
+<aside class="notice">
+  Please note that the actual polling endpoint will be provided in the successful response of the <a href="#get-booking-details">Get booking details</a> request.
+</aside>
+
 *TRY IT OUT*
 
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/31ff523d2ff9186107e1)
@@ -472,9 +472,7 @@ Please refer to our <a href="#response-codes">response codes</a> in case of unsu
 ### Request
 
 ```shell
-curl "https://partners.api.skyscanner.net/{URL returned in Location header}
-    ?apiKey={apiKey}"
-    -X GET
+curl "{URL returned in Get booking details Location header}?apiKey={apiKey}" -X GET
 ```
 Use the URL returned in the `Location` header
 

--- a/source/includes/_flights_live_prices.md
+++ b/source/includes/_flights_live_prices.md
@@ -416,10 +416,6 @@ The full URL and body content are provided in the response from the live pricing
 `PUT /pricing/v1.0/{SessionKey}/booking`
 
 
-<aside class="notice">
-  Please note that the actual polling endpoint will be provided in the successful response of the <a href="#get-booking-details">Get booking details</a> request.
-</aside>
-
 *TRY IT OUT*
 
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/31ff523d2ff9186107e1)
@@ -474,12 +470,14 @@ Please refer to our <a href="#response-codes">response codes</a> in case of unsu
 ```shell
 curl "{URL returned in Get booking details Location header}?apiKey={apiKey}" -X GET
 ```
-Use the URL returned in the `Location` header
 
 *API endpoint*
 
 `GET /pricing/v1.0/{SessionKey}/booking/{OutboundLegId};{InboundLegId}`
 
+<aside class="notice">
+  Please note that the actual polling endpoint will be provided in the successful response of the <a href="#get-booking-details">Get booking details</a> request.
+</aside>
 
 *TRY IT OUT*
 

--- a/source/includes/_flights_live_prices.md
+++ b/source/includes/_flights_live_prices.md
@@ -111,6 +111,8 @@ Please refer to our <a href="#response-codes">response codes</a> in case of unsu
 curl "{URL returned in Creating the session Location header}?apiKey={apiKey}" -X GET
 ```
 
+Please use the URL returned in the Creating the session `Location` header
+
 *API endpoint*
 
 `GET /pricing/v1.0/{SessionKey}`
@@ -470,6 +472,8 @@ Please refer to our <a href="#response-codes">response codes</a> in case of unsu
 ```shell
 curl "{URL returned in Get booking details Location header}?apiKey={apiKey}" -X GET
 ```
+
+Please use the URL returned in the Get booking details `Location` header
 
 *API endpoint*
 

--- a/source/includes/_flights_live_prices.md
+++ b/source/includes/_flights_live_prices.md
@@ -158,7 +158,7 @@ or go to our [test harness](https://www.partners.skyscanner.net/flightsliveprici
 > Example polling request with pagination:
 
 ```shell
-Location "https://partners.api.skyscanner.net/apiservices/pricing/uk1/v1.0/
+Location "https://partners.api.skyscanner.net/apiservices/pricing/v1.0/
     {SessionKey}?apiKey={apiKey}
     &pageIndex=0
     &pageSize=10"
@@ -448,7 +448,7 @@ The full URL and body content are provided in the response from the live pricing
 > Example response:
 
 ```shell
-Location "https://partners.api.skyscanner.net/apiservices/pricing/uk1/v1.0/
+Location "https://partners.api.skyscanner.net/apiservices/pricing/v1.0/
     {SessionKey}/booking/
     {OutboundLegId};{InboundLegId}"
 ```


### PR DESCRIPTION
This adds a notice about the URL used for polling the session details

This is how the change looks:
![image](https://user-images.githubusercontent.com/4840462/109970664-3ac4c700-7ced-11eb-821f-2b1fb164b921.png)
