### PR TITLE
Revert "Add `.md.erb` to `.gitattributes`"

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
 source/javascripts/lib/* linguist-vendored
-*.md.erb            text diff=markdown


### PR DESCRIPTION
Reverts Skyscanner/slate#80

I can't see the `.md.erb` files showing up in the github search, so this specific change didn't work. It's possible I was close, but for now I'll revert 😢 