### PR TITLE
Vul 965 referrals update

### DIFF
--- a/generate_referral_service_docs.sh
+++ b/generate_referral_service_docs.sh
@@ -11,15 +11,15 @@ echo "Parsing ..."
 # Parsing the generated MD files and
 #   * Fixing the headings;
 #   * Removing the json files links
-sed s/^#/##/g ../referrals-api/src/utils/referral/flights/docs/dayView.md | sed s/[\\[\|\(][a-zA-Z]*View\.json[\]\|\)]//g > source/includes/_flights_dayView.md
-sed s/^#/##/g ../referrals-api/src/utils/referral/flights/docs/browseView.md | sed s/[\\[\|\(][a-zA-Z]*View\.json[\]\|\)]//g > source/includes/_flights_browseView.md
-sed s/^#/##/g ../referrals-api/src/utils/referral/flights/docs/calendarMonthView.md | sed s/[\\[\|\(][a-zA-Z]*View\.json[\]\|\)]//g > source/includes/_flights_calendarMonthView.md
-sed s/^#/##/g ../referrals-api/src/utils/referral/flights/docs/multiCity.md | sed s/[\\[\|\(][a-zA-Z]*City\.json[\]\|\)]//g > source/includes/_flights_multiCity.md
-sed s/^#/##/g ../referrals-api/src/utils/referral/flights/docs/flightsHomePage.md | sed s/[\\[\|\(][a-zA-Z]*View\.json[\]\|\)]//g > source/includes/_flights_homeView.md
-sed s/^#/##/g ../referrals-api/src/utils/referral/flights/docs/cheapFlightsTo.md | sed s/[\\[\|\(][a-zA-Z]*City\.json[\]\|\)]//g > source/includes/_flights_cheapFlightsTo.md
-sed s/^#/##/g ../referrals-api/src/utils/referral/flights/docs/flightsAirline.md | sed s/[\\[\|\(][a-zA-Z]*Airline\.json[\]\|\)]//g > source/includes/_flights_airline.md
-sed s/^#/##/g ../referrals-api/src/utils/referral/hotels/docs/dayView.md | sed s/[\\[\|\(][a-zA-Z]*View\.json[\]\|\)]//g > source/includes/_hotels_dayView.md
-sed s/^#/##/g ../referrals-api/src/utils/referral/hotels/docs/homeView.md | sed s/[\\[\|\(][a-zA-Z]*View\.json[\]\|\)]//g > source/includes/_hotels_homeView.md
-sed s/^#/##/g ../referrals-api/src/utils/referral/hotels/docs/hotelDetails.md | sed s/[\\[\|\(][a-zA-Z]*View\.json[\]\|\)]//g > source/includes/_hotels_hotelDetails.md
-sed s/^#/##/g ../referrals-api/src/utils/referral/cars/docs/dayView.md | sed s/[\\[\|\(][a-zA-Z]*View\.json[\]\|\)]//g > source/includes/_cars_dayView.md
-sed s/^#/##/g ../referrals-api/src/utils/referral/cars/docs/carsHome.md | sed s/[\\[\|\(][a-zA-Z]*View\.json[\]\|\)]//g > source/includes/_cars_carsHome.md
+sed s/^#/##/g ../referrals-api/src/utils/referral/flights/docs/dayView.md | sed s/[\\[\|\(][a-zA-Z]*View\.json[\]\|\)]//g > source/includes/_flights_dayView.md.erb
+sed s/^#/##/g ../referrals-api/src/utils/referral/flights/docs/browseView.md | sed s/[\\[\|\(][a-zA-Z]*View\.json[\]\|\)]//g > source/includes/_flights_browseView.md.erb
+sed s/^#/##/g ../referrals-api/src/utils/referral/flights/docs/calendarMonthView.md | sed s/[\\[\|\(][a-zA-Z]*View\.json[\]\|\)]//g > source/includes/_flights_calendarMonthView.md.erb
+sed s/^#/##/g ../referrals-api/src/utils/referral/flights/docs/multiCity.md | sed s/[\\[\|\(][a-zA-Z]*City\.json[\]\|\)]//g > source/includes/_flights_multiCity.md.erb
+sed s/^#/##/g ../referrals-api/src/utils/referral/flights/docs/flightsHomePage.md | sed s/[\\[\|\(][a-zA-Z]*View\.json[\]\|\)]//g > source/includes/_flights_homeView.md.erb
+sed s/^#/##/g ../referrals-api/src/utils/referral/flights/docs/cheapFlightsTo.md | sed s/[\\[\|\(][a-zA-Z]*City\.json[\]\|\)]//g > source/includes/_flights_cheapFlightsTo.md.erb
+sed s/^#/##/g ../referrals-api/src/utils/referral/flights/docs/flightsAirline.md | sed s/[\\[\|\(][a-zA-Z]*Airline\.json[\]\|\)]//g > source/includes/_flights_airline.md.erb
+#sed s/^#/##/g ../referrals-api/src/utils/referral/hotels/docs/dayView.md | sed s/[\\[\|\(][a-zA-Z]*View\.json[\]\|\)]//g > source/includes/_hotels_dayView.md.erb
+#sed s/^#/##/g ../referrals-api/src/utils/referral/hotels/docs/homeView.md | sed s/[\\[\|\(][a-zA-Z]*View\.json[\]\|\)]//g > source/includes/_hotels_homeView.md.erb
+#sed s/^#/##/g ../referrals-api/src/utils/referral/hotels/docs/hotelDetails.md | sed s/[\\[\|\(][a-zA-Z]*View\.json[\]\|\)]//g > source/includes/_hotels_hotelDetails.md.erb
+sed s/^#/##/g ../referrals-api/src/utils/referral/cars/docs/dayView.md | sed s/[\\[\|\(][a-zA-Z]*View\.json[\]\|\)]//g > source/includes/_cars_dayView.md.erb
+sed s/^#/##/g ../referrals-api/src/utils/referral/cars/docs/carsHome.md | sed s/[\\[\|\(][a-zA-Z]*View\.json[\]\|\)]//g > source/includes/_cars_carsHome.md.erb

--- a/source/includes/_cars_carsHome.md.erb
+++ b/source/includes/_cars_carsHome.md.erb
@@ -1,57 +1,83 @@
-## Carhire Home page supported parameters Schema
+## Carhire Home View Schema
 
-```
+```txt
 /cars/home
 ```
 
-| Property              | Type     | Required   | Nullable | Defined by                                           |
-| --------------------- | -------- | ---------- | -------- | ---------------------------------------------------- |
-| [currency](#currency) | `string` | Optional   | No       | Carhire Home page supported parameters (this schema) |
-| [locale](#locale)     | `string` | Optional   | No       | Carhire Home page supported parameters (this schema) |
-| [market](#market)     | `string` | Optional   | No       | Carhire Home page supported parameters (this schema) |
-| `*`                   | any      | Additional | Yes      | this schema _allows_ additional properties           |
+A schema definition for the carhire home page microsite supported parameters
 
-### currency
+| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions |
+| :------------------ | :--------- | :------------- | :----------- | :---------------- | :-------------------- | :------------------ |
+| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                |
 
-The desired currency for the page. Examples: GBP, EUR, USD  
-Please try to avoid using `locale`, `market`, and `currency`, as these values will be governed by Skyscanner market detection logic on the Skyscanner site. If you believe you need to use these, please discuss with your account manager.
+### Carhire Home View Type
 
-`currency`
+`object` ([Carhire Home View](carshome.md))
 
-- is optional
-- type: `string`
-- defined in this schema
+## Carhire Home View Properties
 
-#### currency Type
-
-`string`
-
-### locale
-
-The desired locale for the page. Examples: es-ES, en-GB, ru-RU  
-Please try to avoid using `locale`, `market` and `currency`, as these values will be governed by Skyscanner market detection logic on the Skyscanner site. If you believe you need to use these, please discuss with your account manager.
-
-`locale`
-
-- is optional
-- type: `string`
-- defined in this schema
-
-#### locale Type
-
-`string`
+| Property              | Type     | Required | Nullable       |
+| :-------------------- | :------- | :------- | :------------- |
+| [market](#market)     | `string` | Optional | cannot be null |
+| [locale](#locale)     | `string` | Optional | cannot be null |
+| [currency](#currency) | `string` | Optional | cannot be null |
 
 ### market
 
-The market of the user. Examples: UK, US, ES  
-Please try to avoid using `locale`, `market` and `currency`, as these values will be governed by Skyscanner market detection logic on the Skyscanner site. If you believe you need to use these, please discuss with your account manager.
+The market of the user. Examples: UK, US, ES
 
 `market`
 
-- is optional
-- type: `string`
-- defined in this schema
+*   is optional
+
+*   Type: `string` ([Market](carshome-properties-market.md))
+
+*   cannot be null
 
 #### market Type
 
-`string`
+`string` ([Market](carshome-properties-market.md))
+
+#### market Constraints
+
+**unknown format**: the value of this string must follow the format: `market`
+
+### locale
+
+The desired locale for the page. Examples: es-ES, en-GB, ru-RU
+
+`locale`
+
+*   is optional
+
+*   Type: `string` ([Locale](carshome-properties-locale.md))
+
+*   cannot be null
+
+#### locale Type
+
+`string` ([Locale](carshome-properties-locale.md))
+
+#### locale Constraints
+
+**unknown format**: the value of this string must follow the format: `locale`
+
+### currency
+
+The desired currency for the page. Examples: GBP, EUR, USD
+
+`currency`
+
+*   is optional
+
+*   Type: `string` ([Currency](carshome-properties-currency.md))
+
+*   cannot be null
+
+#### currency Type
+
+`string` ([Currency](carshome-properties-currency.md))
+
+#### currency Constraints
+
+**unknown format**: the value of this string must follow the format: `currency`

--- a/source/includes/_cars_dayView.md.erb
+++ b/source/includes/_cars_dayView.md.erb
@@ -1,107 +1,31 @@
-## Carhire Day View supported parameters Schema
+## Carhire Day View Schema
 
-```
+```txt
 /cars/day-view
 ```
 
-| Property                      | Type      | Required     | Nullable | Defined by                                          |
-| ----------------------------- | --------- | ------------ | -------- | --------------------------------------------------- |
-| [currency](#currency)         | `string`  | Optional     | No       | Carhire Day View supported parameters (this schema) |
-| [driverAge](#driverage)       | `integer` | **Required** | No       | Carhire Day View supported parameters (this schema) |
-| [dropoffPlace](#dropoffplace) | `string`  | Optional     | No       | Carhire Day View supported parameters (this schema) |
-| [dropoffTime](#dropofftime)   | `string`  | **Required** | No       | Carhire Day View supported parameters (this schema) |
-| [locale](#locale)             | `string`  | Optional     | No       | Carhire Day View supported parameters (this schema) |
-| [market](#market)             | `string`  | Optional     | No       | Carhire Day View supported parameters (this schema) |
-| [pickupPlace](#pickupplace)   | `string`  | **Required** | No       | Carhire Day View supported parameters (this schema) |
-| [pickupTime](#pickuptime)     | `string`  | **Required** | No       | Carhire Day View supported parameters (this schema) |
-| `*`                           | any       | Additional   | Yes      | this schema _allows_ additional properties          |
+A schema definition for the carhire day-view microsite supported parameters
 
-### currency
+| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions |
+| :------------------ | :--------- | :------------- | :----------- | :---------------- | :-------------------- | :------------------ |
+| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                |
 
-The desired currency for the page. Examples: GBP, EUR, USD    
-Please try to avoid using `locale`, `market` and `currency` as these values will be governed by Skyscanner market detection logic on the Skyscanner site. If you believe you need to use these, please discuss with your account manager.
+### Carhire Day View Type
 
-`currency`
+`object` ([Carhire Day View](dayview.md))
 
-- is optional
-- type: `string`
-- defined in this schema
+## Carhire Day View Properties
 
-#### currency Type
-
-`string`
-
-### driverAge
-
-Driver age between 21 and 99
-
-`driverAge`
-
-- is **required**
-- type: `integer`
-- defined in this schema
-
-#### driverAge Type
-
-`integer`
-
-### dropoffPlace
-
-Pick up IATA code / hotel or city entity id
-
-`dropoffPlace`
-
-- is optional
-- type: `string`
-- defined in this schema
-
-#### dropoffPlace Type
-
-`string`
-
-### dropoffTime
-
-Drop Off Datetime in ISO 8601 standard. I.e YYYY-MM-DDTHH:MM
-
-`dropoffTime`
-
-- is **required**
-- type: `string`
-- defined in this schema
-
-#### dropoffTime Type
-
-`string`
-
-### locale
-
-The desired locale for the page. Examples: es-ES, en-GB, ru-RU
-Please try to avoid using `locale`, `market` and `currency`, as these values will be governed by Skyscanner market detection logic on the Skyscanner site. If you believe you need to use these, please discuss with your account manager.
-
-`locale`
-
-- is optional
-- type: `string`
-- defined in this schema
-
-#### locale Type
-
-`string`
-
-### market
-
-The market of the user. Examples: UK, US, ES  
-Please try to avoid using `locale`, `market` and `currency`, as these values will be governed by Skyscanner market detection logic on the Skyscanner site. If you believe you need to use these, please discuss with your account manager.
-
-`market`
-
-- is optional
-- type: `string`
-- defined in this schema
-
-#### market Type
-
-`string`
+| Property                      | Type      | Required | Nullable       |
+| :---------------------------- | :-------- | :------- | :------------- |
+| [pickupPlace](#pickupplace)   | `string`  | Required | cannot be null |
+| [dropoffPlace](#dropoffplace) | `string`  | Optional | cannot be null |
+| [pickupTime](#pickuptime)     | `string`  | Required | cannot be null |
+| [dropoffTime](#dropofftime)   | `string`  | Required | cannot be null |
+| [driverAge](#driverage)       | `integer` | Required | cannot be null |
+| [market](#market)             | `string`  | Optional | cannot be null |
+| [locale](#locale)             | `string`  | Optional | cannot be null |
+| [currency](#currency)         | `string`  | Optional | cannot be null |
 
 ### pickupPlace
 
@@ -109,13 +33,39 @@ Pick up IATA code / hotel or city entity id
 
 `pickupPlace`
 
-- is **required**
-- type: `string`
-- defined in this schema
+*   is required
+
+*   Type: `string` ([Pickup](dayview-properties-pickup.md))
+
+*   cannot be null
 
 #### pickupPlace Type
 
-`string`
+`string` ([Pickup](dayview-properties-pickup.md))
+
+#### pickupPlace Constraints
+
+**unknown format**: the value of this string must follow the format: `carhire-place`
+
+### dropoffPlace
+
+Pick up IATA code / hotel or city entity id
+
+`dropoffPlace`
+
+*   is optional
+
+*   Type: `string` ([Drop off](dayview-properties-drop-off.md))
+
+*   cannot be null
+
+#### dropoffPlace Type
+
+`string` ([Drop off](dayview-properties-drop-off.md))
+
+#### dropoffPlace Constraints
+
+**unknown format**: the value of this string must follow the format: `carhire-place`
 
 ### pickupTime
 
@@ -123,10 +73,116 @@ Pick Up Datetime in ISO 8601 standard. I.e YYYY-MM-DDTHH:MM
 
 `pickupTime`
 
-- is **required**
-- type: `string`
-- defined in this schema
+*   is required
+
+*   Type: `string` ([Pickup time](dayview-properties-pickup-time.md))
+
+*   cannot be null
 
 #### pickupTime Type
 
-`string`
+`string` ([Pickup time](dayview-properties-pickup-time.md))
+
+#### pickupTime Constraints
+
+**unknown format**: the value of this string must follow the format: `date-yyyy-mm-ddThh:mm`
+
+### dropoffTime
+
+Drop Off Datetime in ISO 8601 standard. I.e YYYY-MM-DDTHH:MM
+
+`dropoffTime`
+
+*   is required
+
+*   Type: `string` ([Drop off time](dayview-properties-drop-off-time.md))
+
+*   cannot be null
+
+#### dropoffTime Type
+
+`string` ([Drop off time](dayview-properties-drop-off-time.md))
+
+#### dropoffTime Constraints
+
+**unknown format**: the value of this string must follow the format: `date-yyyy-mm-ddThh:mm`
+
+### driverAge
+
+Driver age between 21 and 99
+
+`driverAge`
+
+*   is required
+
+*   Type: `integer` ([Driver's age](dayview-properties-drivers-age.md))
+
+*   cannot be null
+
+#### driverAge Type
+
+`integer` ([Driver's age](dayview-properties-drivers-age.md))
+
+#### driverAge Constraints
+
+**unknown format**: the value of this string must follow the format: `driver-age`
+
+### market
+
+The market of the user. Examples: UK, US, ES
+
+`market`
+
+*   is optional
+
+*   Type: `string` ([Market](dayview-properties-market.md))
+
+*   cannot be null
+
+#### market Type
+
+`string` ([Market](dayview-properties-market.md))
+
+#### market Constraints
+
+**unknown format**: the value of this string must follow the format: `market`
+
+### locale
+
+The desired locale for the page. Examples: es-ES, en-GB, ru-RU
+
+`locale`
+
+*   is optional
+
+*   Type: `string` ([Locale](dayview-properties-locale.md))
+
+*   cannot be null
+
+#### locale Type
+
+`string` ([Locale](dayview-properties-locale.md))
+
+#### locale Constraints
+
+**unknown format**: the value of this string must follow the format: `locale`
+
+### currency
+
+The desired currency for the page. Examples: GBP, EUR, USD
+
+`currency`
+
+*   is optional
+
+*   Type: `string` ([Currency](dayview-properties-currency.md))
+
+*   cannot be null
+
+#### currency Type
+
+`string` ([Currency](dayview-properties-currency.md))
+
+#### currency Constraints
+
+**unknown format**: the value of this string must follow the format: `currency`

--- a/source/includes/_flights_airline.md.erb
+++ b/source/includes/_flights_airline.md.erb
@@ -1,17 +1,28 @@
-## Flights Airline supported parameters Schema
+## Flights Airline Schema
 
-```
+```txt
 /flights/flights-airline
 ```
 
-| Property                    | Type     | Required     | Nullable | Defined by                                         |
-| --------------------------- | -------- | ------------ | -------- | -------------------------------------------------- |
-| [airlineCode](#airlinecode) | `string` | **Required** | No       | Flights Airline supported parameters (this schema) |
-| [airlineName](#airlinename) | `string` | Optional     | No       | Flights Airline supported parameters (this schema) |
-| [currency](#currency)       | `string` | Optional     | No       | Flights Airline supported parameters (this schema) |
-| [locale](#locale)           | `string` | Optional     | No       | Flights Airline supported parameters (this schema) |
-| [market](#market)           | `string` | Optional     | No       | Flights Airline supported parameters (this schema) |
-| `*`                         | any      | Additional   | Yes      | this schema _allows_ additional properties         |
+A schema definition for the flights airline microsite supported parameters
+
+| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions |
+| :------------------ | :--------- | :------------- | :----------- | :---------------- | :-------------------- | :------------------ |
+| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                |
+
+### Flights Airline Type
+
+`object` ([Flights Airline](flightsairline.md))
+
+## Flights Airline Properties
+
+| Property                    | Type     | Required | Nullable       |
+| :-------------------------- | :------- | :------- | :------------- |
+| [airlineCode](#airlinecode) | `string` | Required | cannot be null |
+| [airlineName](#airlinename) | `string` | Optional | cannot be null |
+| [market](#market)           | `string` | Optional | cannot be null |
+| [locale](#locale)           | `string` | Optional | cannot be null |
+| [currency](#currency)       | `string` | Optional | cannot be null |
 
 ### airlineCode
 
@@ -19,13 +30,19 @@ The airline code.
 
 `airlineCode`
 
-- is **required**
-- type: `string`
-- defined in this schema
+*   is required
+
+*   Type: `string` ([The airline code.](flightsairline-properties-the-airline-code.md))
+
+*   cannot be null
 
 #### airlineCode Type
 
-`string`
+`string` ([The airline code.](flightsairline-properties-the-airline-code.md))
+
+#### airlineCode Constraints
+
+**unknown format**: the value of this string must follow the format: `airline-code`
 
 ### airlineName
 
@@ -33,55 +50,76 @@ The airline name.
 
 `airlineName`
 
-- is optional
-- type: `string`
-- defined in this schema
+*   is optional
+
+*   Type: `string` ([The airline name.](flightsairline-properties-the-airline-name.md))
+
+*   cannot be null
 
 #### airlineName Type
 
-`string`
+`string` ([The airline name.](flightsairline-properties-the-airline-name.md))
 
-### currency
+#### airlineName Constraints
 
-The desired currency for the page. Examples: GBP, EUR, USD  
-Please try to avoid using `locale`, `market` and `currency`, as these values will be governed by Skyscanner market detection logic on the Skyscanner site. If you believe you need to use these, please discuss with your account manager.
-
-`currency`
-
-- is optional
-- type: `string`
-- defined in this schema
-
-#### currency Type
-
-`string`
-
-### locale
-
-The desired locale for the page. Examples: es-ES, en-GB, ru-RU  
-Please try to avoid using `locale`, `market` and `currency`, as these values will be governed by Skyscanner market detection logic on the Skyscanner site. If you believe you need to use these, please discuss with your account manager.
-
-`locale`
-
-- is optional
-- type: `string`
-- defined in this schema
-
-#### locale Type
-
-`string`
+**unknown format**: the value of this string must follow the format: `airline-name`
 
 ### market
 
-The market of the user. Examples: UK, US, ES  
-Please try to avoid using `locale`, `market` and `currency`, as these values will be governed by Skyscanner market detection logic on the Skyscanner site. If you believe you need to use these, please discuss with your account manager.
+The market of the user. Examples: UK, US, ES
 
 `market`
 
-- is optional
-- type: `string`
-- defined in this schema
+*   is optional
+
+*   Type: `string` ([Market](flightsairline-properties-market.md))
+
+*   cannot be null
 
 #### market Type
 
-`string`
+`string` ([Market](flightsairline-properties-market.md))
+
+#### market Constraints
+
+**unknown format**: the value of this string must follow the format: `market`
+
+### locale
+
+The desired locale for the page. Examples: es-ES, en-GB, ru-RU
+
+`locale`
+
+*   is optional
+
+*   Type: `string` ([Locale](flightsairline-properties-locale.md))
+
+*   cannot be null
+
+#### locale Type
+
+`string` ([Locale](flightsairline-properties-locale.md))
+
+#### locale Constraints
+
+**unknown format**: the value of this string must follow the format: `locale`
+
+### currency
+
+The desired currency for the page. Examples: GBP, EUR, USD
+
+`currency`
+
+*   is optional
+
+*   Type: `string` ([Currency](flightsairline-properties-currency.md))
+
+*   cannot be null
+
+#### currency Type
+
+`string` ([Currency](flightsairline-properties-currency.md))
+
+#### currency Constraints
+
+**unknown format**: the value of this string must follow the format: `currency`

--- a/source/includes/_flights_browseView.md.erb
+++ b/source/includes/_flights_browseView.md.erb
@@ -1,158 +1,37 @@
-## Flights Browse View supported parameters Schema
+## Flights Browse View Schema
 
-```
+```txt
 /flights/browse-view
 ```
 
-| Property                        | Type      | Required     | Nullable | Defined by                                             |
-| ------------------------------- | --------- | ------------ | -------- | ------------------------------------------------------ |
-| [adultsv2](#adultsv2)           | `integer` | Optional     | No       | Flights Browse View supported parameters (this schema) |
-| [childrenv2](#childrenv2)       | `string`  | Optional     | No       | Flights Browse View supported parameters (this schema) |
-| [currency](#currency)           | `string`  | Optional     | No       | Flights Browse View supported parameters (this schema) |
-| [destination](#destination)     | `string`  | Optional     | No       | Flights Browse View supported parameters (this schema) |
-| [inboundDate](#inbounddate)     | `string`  | Optional     | No       | Flights Browse View supported parameters (this schema) |
-| [infants](#infants)             | `integer` | Optional     | No       | Flights Browse View supported parameters (this schema) |
-| [iym](#iym)                     | `string`  | Optional     | No       | Flights Browse View supported parameters (this schema) |
-| [locale](#locale)               | `string`  | Optional     | No       | Flights Browse View supported parameters (this schema) |
-| [market](#market)               | `string`  | Optional     | No       | Flights Browse View supported parameters (this schema) |
-| [origin](#origin)               | `string`  | **Required** | No       | Flights Browse View supported parameters (this schema) |
-| [outboundDate](#outbounddate)   | `string`  | Optional     | No       | Flights Browse View supported parameters (this schema) |
-| [oym](#oym)                     | `string`  | Optional     | No       | Flights Browse View supported parameters (this schema) |
-| [preferDirects](#preferdirects) | `boolean` | Optional     | No       | Flights Browse View supported parameters (this schema) |
-| [rtn](#rtn)                     | `enum`    | Optional     | No       | Flights Browse View supported parameters (this schema) |
-| `*`                             | any       | Additional   | Yes      | this schema _allows_ additional properties             |
+A schema definition for the flights browse view microsite supported parameters
 
-### adultsv2
+| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions |
+| :------------------ | :--------- | :------------- | :----------- | :---------------- | :-------------------- | :------------------ |
+| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                |
 
-Number of adult passengers. Adults have to be 16 years old or older.
+### Flights Browse View Type
 
-`adultsv2`
+`object` ([Flights Browse View](browseview.md))
 
-- is optional
-- type: `integer`
-- defined in this schema
+## Flights Browse View Properties
 
-#### adultsv2 Type
-
-`integer`
-
-- minimum value: `1`
-
-### childrenv2
-
-Number of child passengers. The value must be in the format integer|integer.. where each number is the age of the child
-passenger
-
-`childrenv2`
-
-- is optional
-- type: `string`
-- defined in this schema
-
-#### childrenv2 Type
-
-`string`
-
-### currency
-
-The desired currency for the page. Examples: GBP, EUR, USD  
-Please try to avoid using `locale`, `market` and `currency`, as these values will be governed by Skyscanner market detection logic on the Skyscanner site. If you believe you need to use these, please discuss with your account manager.
-
-`currency`
-
-- is optional
-- type: `string`
-- defined in this schema
-
-#### currency Type
-
-`string`
-
-### destination
-
-Location code for the destination
-
-`destination`
-
-- is optional
-- type: `string`
-- defined in this schema
-
-#### destination Type
-
-`string`
-
-### inboundDate
-
-Inbound date in the format YYYY-MM-DD
-
-`inboundDate`
-
-- is optional
-- type: `string`
-- defined in this schema
-
-#### inboundDate Type
-
-`string`
-
-### infants
-
-Number of infant passengers. An infant is 1 year old or younger.
-
-`infants`
-
-- is optional
-- type: `integer`
-- defined in this schema
-
-#### infants Type
-
-`integer`
-
-### iym
-
-Arrival date in the format: YYYY-MM
-
-`iym`
-
-- is optional
-- type: `string`
-- defined in this schema
-
-#### iym Type
-
-`string`
-
-### locale
-
-The desired locale for the page. Examples: es-ES, en-GB, ru-RU  
-Please try to avoid using `locale`, `market` and `currency`, as these values will be governed by Skyscanner market detection logic on the Skyscanner site. If you believe you need to use these, please discuss with your account manager.
-
-`locale`
-
-- is optional
-- type: `string`
-- defined in this schema
-
-#### locale Type
-
-`string`
-
-### market
-
-The market of the user. Examples: UK, US, ES  
-Please try to avoid using `locale`, `market` and `currency`, as these values will be governed by Skyscanner market detection logic on the Skyscanner site. If you believe you need to use these, please discuss with your account manager.
-
-`market`
-
-- is optional
-- type: `string`
-- defined in this schema
-
-#### market Type
-
-`string`
+| Property                        | Type      | Required | Nullable       |
+| :------------------------------ | :-------- | :------- | :------------- |
+| [origin](#origin)               | `string`  | Required | cannot be null |
+| [destination](#destination)     | `string`  | Optional | cannot be null |
+| [outboundDate](#outbounddate)   | `string`  | Optional | cannot be null |
+| [inboundDate](#inbounddate)     | `string`  | Optional | cannot be null |
+| [adultsv2](#adultsv2)           | `integer` | Optional | cannot be null |
+| [childrenv2](#childrenv2)       | `string`  | Optional | cannot be null |
+| [infants](#infants)             | `integer` | Optional | cannot be null |
+| [oym](#oym)                     | `string`  | Optional | cannot be null |
+| [iym](#iym)                     | `string`  | Optional | cannot be null |
+| [rtn](#rtn)                     | `string`  | Optional | cannot be null |
+| [preferDirects](#preferdirects) | `boolean` | Optional | cannot be null |
+| [market](#market)               | `string`  | Optional | cannot be null |
+| [locale](#locale)               | `string`  | Optional | cannot be null |
+| [currency](#currency)           | `string`  | Optional | cannot be null |
 
 ### origin
 
@@ -160,13 +39,39 @@ Location code for the origin
 
 `origin`
 
-- is **required**
-- type: `string`
-- defined in this schema
+*   is required
+
+*   Type: `string` ([Origin](browseview-properties-origin.md))
+
+*   cannot be null
 
 #### origin Type
 
-`string`
+`string` ([Origin](browseview-properties-origin.md))
+
+#### origin Constraints
+
+**unknown format**: the value of this string must follow the format: `place`
+
+### destination
+
+Location code for the destination
+
+`destination`
+
+*   is optional
+
+*   Type: `string` ([Destination](browseview-properties-destination.md))
+
+*   cannot be null
+
+#### destination Type
+
+`string` ([Destination](browseview-properties-destination.md))
+
+#### destination Constraints
+
+**unknown format**: the value of this string must follow the format: `place`
 
 ### outboundDate
 
@@ -174,13 +79,95 @@ Outbound date in the format YYYY-MM-DD
 
 `outboundDate`
 
-- is optional
-- type: `string`
-- defined in this schema
+*   is optional
+
+*   Type: `string` ([Outbound date](browseview-properties-outbound-date.md))
+
+*   cannot be null
 
 #### outboundDate Type
 
-`string`
+`string` ([Outbound date](browseview-properties-outbound-date.md))
+
+#### outboundDate Constraints
+
+**unknown format**: the value of this string must follow the format: `date-as-provided`
+
+### inboundDate
+
+Inbound date in the format YYYY-MM-DD
+
+`inboundDate`
+
+*   is optional
+
+*   Type: `string` ([Inbound date](browseview-properties-inbound-date.md))
+
+*   cannot be null
+
+#### inboundDate Type
+
+`string` ([Inbound date](browseview-properties-inbound-date.md))
+
+#### inboundDate Constraints
+
+**unknown format**: the value of this string must follow the format: `date-as-provided`
+
+### adultsv2
+
+Number of adult passengers. Adults have to be 16 years old or older.
+
+`adultsv2`
+
+*   is optional
+
+*   Type: `integer` ([Adult passengers. Adults have to be 16 years old or older.](browseview-properties-adult-passengers-adults-have-to-be-16-years-old-or-older.md))
+
+*   cannot be null
+
+#### adultsv2 Type
+
+`integer` ([Adult passengers. Adults have to be 16 years old or older.](browseview-properties-adult-passengers-adults-have-to-be-16-years-old-or-older.md))
+
+#### adultsv2 Constraints
+
+**minimum**: the value of this number must greater than or equal to: `1`
+
+### childrenv2
+
+Number of child passengers. The value must be in the format integer|integer.. where each number is the age of the child passenger
+
+`childrenv2`
+
+*   is optional
+
+*   Type: `string` ([Child passengers. Add a child and specify the age (must be from 2 to 15).](browseview-properties-child-passengers-add-a-child-and-specify-the-age-must-be-from-2-to-15.md))
+
+*   cannot be null
+
+#### childrenv2 Type
+
+`string` ([Child passengers. Add a child and specify the age (must be from 2 to 15).](browseview-properties-child-passengers-add-a-child-and-specify-the-age-must-be-from-2-to-15.md))
+
+#### childrenv2 Constraints
+
+**unknown format**: the value of this string must follow the format: `delimited-ages`
+
+### infants
+
+Number of infant passengers. An infant is 1 year old or younger.
+
+`infants`
+
+*   is optional
+
+*   Type: `integer` ([Infant passengers. An infant is 1 year old or younger.](browseview-properties-infant-passengers-an-infant-is-1-year-old-or-younger.md))
+
+*   cannot be null
+
+#### infants Type
+
+`integer` ([Infant passengers. An infant is 1 year old or younger.](browseview-properties-infant-passengers-an-infant-is-1-year-old-or-younger.md))
 
 ### oym
 
@@ -188,13 +175,64 @@ Departure date in the format: YYYY-MM
 
 `oym`
 
-- is optional
-- type: `string`
-- defined in this schema
+*   is optional
+
+*   Type: `string` ([Departure date](browseview-properties-departure-date.md))
+
+*   cannot be null
 
 #### oym Type
 
-`string`
+`string` ([Departure date](browseview-properties-departure-date.md))
+
+#### oym Constraints
+
+**unknown format**: the value of this string must follow the format: `date-yymm`
+
+### iym
+
+Arrival date in the format: YYYY-MM
+
+`iym`
+
+*   is optional
+
+*   Type: `string` ([Arrival date](browseview-properties-arrival-date.md))
+
+*   cannot be null
+
+#### iym Type
+
+`string` ([Arrival date](browseview-properties-arrival-date.md))
+
+#### iym Constraints
+
+**unknown format**: the value of this string must follow the format: `date-yymm`
+
+### rtn
+
+Trip type: 0 if oneway or 1 if return or multicity trip
+
+`rtn`
+
+*   is optional
+
+*   Type: `string` ([Trip type](browseview-properties-trip-type.md))
+
+*   cannot be null
+
+#### rtn Type
+
+`string` ([Trip type](browseview-properties-trip-type.md))
+
+#### rtn Constraints
+
+**enum**: the value of this property must be equal to one of the following values:
+
+| Value | Explanation |
+| :---- | :---------- |
+| `"0"` |             |
+| `"1"` |             |
 
 ### preferDirects
 
@@ -202,29 +240,72 @@ Will search only for direct flights if the value is true
 
 `preferDirects`
 
-- is optional
-- type: `boolean`
-- defined in this schema
+*   is optional
+
+*   Type: `boolean` ([Direct flights preferred](browseview-properties-direct-flights-preferred.md))
+
+*   cannot be null
 
 #### preferDirects Type
 
-`boolean`
+`boolean` ([Direct flights preferred](browseview-properties-direct-flights-preferred.md))
 
-### rtn
+### market
 
-Trip type: 0 if oneway or 1 if return trip
+The market of the user. Examples: UK, US, ES
 
-`rtn`
+`market`
 
-- is optional
-- type: `enum`
-- defined in this schema
+*   is optional
 
-The value of this property **must** be equal to one of the [known values below](#rtn-known-values).
+*   Type: `string` ([Market](browseview-properties-market.md))
 
-#### rtn Known Values
+*   cannot be null
 
-| Value | Description |
-| ----- | ----------- |
-| `0`   |             |
-| `1`   |             |
+#### market Type
+
+`string` ([Market](browseview-properties-market.md))
+
+#### market Constraints
+
+**unknown format**: the value of this string must follow the format: `market`
+
+### locale
+
+The desired locale for the page. Examples: es-ES, en-GB, ru-RU
+
+`locale`
+
+*   is optional
+
+*   Type: `string` ([Locale](browseview-properties-locale.md))
+
+*   cannot be null
+
+#### locale Type
+
+`string` ([Locale](browseview-properties-locale.md))
+
+#### locale Constraints
+
+**unknown format**: the value of this string must follow the format: `locale`
+
+### currency
+
+The desired currency for the page. Examples: GBP, EUR, USD
+
+`currency`
+
+*   is optional
+
+*   Type: `string` ([Currency](browseview-properties-currency.md))
+
+*   cannot be null
+
+#### currency Type
+
+`string` ([Currency](browseview-properties-currency.md))
+
+#### currency Constraints
+
+**unknown format**: the value of this string must follow the format: `currency`

--- a/source/includes/_flights_calendarMonthView.md.erb
+++ b/source/includes/_flights_calendarMonthView.md.erb
@@ -1,142 +1,37 @@
-## Flights Calendar Month View supported parameters Schema
+## Flights Calendar Month View Schema
 
-```
+```txt
 /flights/calendar-month-view
 ```
 
-| Property                        | Type      | Required     | Nullable | Defined by                                                     |
-| ------------------------------- | --------- | ------------ | -------- | -------------------------------------------------------------- |
-| [adultsv2](#adultsv2)           | `integer` | Optional     | No       | Flights Calendar Month View supported parameters (this schema) |
-| [childrenv2](#childrenv2)       | `string`  | Optional     | No       | Flights Calendar Month View supported parameters (this schema) |
-| [currency](#currency)           | `string`  | Optional     | No       | Flights Calendar Month View supported parameters (this schema) |
-| [destination](#destination)     | `string`  | **Required** | No       | Flights Calendar Month View supported parameters (this schema) |
-| [infants](#infants)             | `integer` | Optional     | No       | Flights Calendar Month View supported parameters (this schema) |
-| [iym](#iym)                     | `string`  | **Required** | No       | Flights Calendar Month View supported parameters (this schema) |
-| [locale](#locale)               | `string`  | Optional     | No       | Flights Calendar Month View supported parameters (this schema) |
-| [market](#market)               | `string`  | Optional     | No       | Flights Calendar Month View supported parameters (this schema) |
-| [origin](#origin)               | `string`  | **Required** | No       | Flights Calendar Month View supported parameters (this schema) |
-| [oym](#oym)                     | `string`  | **Required** | No       | Flights Calendar Month View supported parameters (this schema) |
-| [preferDirects](#preferdirects) | `boolean` | Optional     | No       | Flights Calendar Month View supported parameters (this schema) |
-| [rtn](#rtn)                     | `enum`    | Optional     | No       | Flights Calendar Month View supported parameters (this schema) |
-| `*`                             | any       | Additional   | Yes      | this schema _allows_ additional properties                     |
+A schema definition for the flights calendar month view microsite supported parameters
 
-### adultsv2
+| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions |
+| :------------------ | :--------- | :------------- | :----------- | :---------------- | :-------------------- | :------------------ |
+| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                |
 
-Number of adult passengers. Adults have to be 16 years old or older.
+### Flights Calendar Month View Type
 
-`adultsv2`
+`object` ([Flights Calendar Month View](calendarmonthview.md))
 
-- is optional
-- type: `integer`
-- defined in this schema
+## Flights Calendar Month View Properties
 
-#### adultsv2 Type
-
-`integer`
-
-- minimum value: `1`
-
-### childrenv2
-
-Number of child passengers. The value must be in the format integer|integer.. where each number is the age of the child
-passenger
-
-`childrenv2`
-
-- is optional
-- type: `string`
-- defined in this schema
-
-#### childrenv2 Type
-
-`string`
-
-### currency
-
-The desired currency for the page. Examples: GBP, EUR, USD  
-Please try to avoid using `locale`, `market` and `currency`, as these values will be governed by Skyscanner market detection logic on the Skyscanner site. If you believe you need to use these, please discuss with your account manager.
-
-`currency`
-
-- is optional
-- type: `string`
-- defined in this schema
-
-#### currency Type
-
-`string`
-
-### destination
-
-Location code for the destination
-
-`destination`
-
-- is **required**
-- type: `string`
-- defined in this schema
-
-#### destination Type
-
-`string`
-
-### infants
-
-Number of infant passengers. An infant is 1 year old or younger.
-
-`infants`
-
-- is optional
-- type: `integer`
-- defined in this schema
-
-#### infants Type
-
-`integer`
-
-### iym
-
-Arrival date in the format: YYYY-MM
-
-`iym`
-
-- is **required**
-- type: `string`
-- defined in this schema
-
-#### iym Type
-
-`string`
-
-### locale
-
-The desired locale for the page. Examples: es-ES, en-GB, ru-RU  
-Please try to avoid using `locale`, `market` and `currency`, as these values will be governed by Skyscanner market detection logic on the Skyscanner site. If you believe you need to use these, please discuss with your account manager.
-
-`locale`
-
-- is optional
-- type: `string`
-- defined in this schema
-
-#### locale Type
-
-`string`
-
-### market
-
-The market of the user. Examples: UK, US, ES  
-Please try to avoid using `locale`, `market` and `currency`, as these values will be governed by Skyscanner market detection logic on the Skyscanner site. If you believe you need to use these, please discuss with your account manager.
-
-`market`
-
-- is optional
-- type: `string`
-- defined in this schema
-
-#### market Type
-
-`string`
+| Property                        | Type      | Required | Nullable       |
+| :------------------------------ | :-------- | :------- | :------------- |
+| [origin](#origin)               | `string`  | Required | cannot be null |
+| [destination](#destination)     | `string`  | Required | cannot be null |
+| [oym](#oym)                     | `string`  | Optional | cannot be null |
+| [iym](#iym)                     | `string`  | Optional | cannot be null |
+| [adultsv2](#adultsv2)           | `integer` | Optional | cannot be null |
+| [childrenv2](#childrenv2)       | `string`  | Optional | cannot be null |
+| [infants](#infants)             | `integer` | Optional | cannot be null |
+| [rtn](#rtn)                     | `string`  | Optional | cannot be null |
+| [preferDirects](#preferdirects) | `boolean` | Optional | cannot be null |
+| [selectedoday](#selectedoday)   | `string`  | Optional | cannot be null |
+| [selectediday](#selectediday)   | `string`  | Optional | cannot be null |
+| [market](#market)               | `string`  | Optional | cannot be null |
+| [locale](#locale)               | `string`  | Optional | cannot be null |
+| [currency](#currency)           | `string`  | Optional | cannot be null |
 
 ### origin
 
@@ -144,13 +39,39 @@ Location code for the origin
 
 `origin`
 
-- is **required**
-- type: `string`
-- defined in this schema
+*   is required
+
+*   Type: `string` ([Origin](calendarmonthview-properties-origin.md))
+
+*   cannot be null
 
 #### origin Type
 
-`string`
+`string` ([Origin](calendarmonthview-properties-origin.md))
+
+#### origin Constraints
+
+**unknown format**: the value of this string must follow the format: `place`
+
+### destination
+
+Location code for the destination
+
+`destination`
+
+*   is required
+
+*   Type: `string` ([Destination](calendarmonthview-properties-destination.md))
+
+*   cannot be null
+
+#### destination Type
+
+`string` ([Destination](calendarmonthview-properties-destination.md))
+
+#### destination Constraints
+
+**unknown format**: the value of this string must follow the format: `place`
 
 ### oym
 
@@ -158,13 +79,120 @@ Departure date in the format: YYYY-MM
 
 `oym`
 
-- is **required**
-- type: `string`
-- defined in this schema
+*   is optional
+
+*   Type: `string` ([Departure date](calendarmonthview-properties-departure-date.md))
+
+*   cannot be null
 
 #### oym Type
 
-`string`
+`string` ([Departure date](calendarmonthview-properties-departure-date.md))
+
+#### oym Constraints
+
+**unknown format**: the value of this string must follow the format: `date-yymm`
+
+### iym
+
+Arrival date in the format: YYYY-MM
+
+`iym`
+
+*   is optional
+
+*   Type: `string` ([Arrival date](calendarmonthview-properties-arrival-date.md))
+
+*   cannot be null
+
+#### iym Type
+
+`string` ([Arrival date](calendarmonthview-properties-arrival-date.md))
+
+#### iym Constraints
+
+**unknown format**: the value of this string must follow the format: `date-yymm`
+
+### adultsv2
+
+Number of adult passengers. Adults have to be 16 years old or older.
+
+`adultsv2`
+
+*   is optional
+
+*   Type: `integer` ([Adult passengers. Adults have to be 16 years old or older.](calendarmonthview-properties-adult-passengers-adults-have-to-be-16-years-old-or-older.md))
+
+*   cannot be null
+
+#### adultsv2 Type
+
+`integer` ([Adult passengers. Adults have to be 16 years old or older.](calendarmonthview-properties-adult-passengers-adults-have-to-be-16-years-old-or-older.md))
+
+#### adultsv2 Constraints
+
+**minimum**: the value of this number must greater than or equal to: `1`
+
+### childrenv2
+
+Number of child passengers. The value must be in the format integer|integer.. where each number is the age of the child passenger
+
+`childrenv2`
+
+*   is optional
+
+*   Type: `string` ([Child passengers. Add a child and specify the age (must be from 2 to 15).](calendarmonthview-properties-child-passengers-add-a-child-and-specify-the-age-must-be-from-2-to-15.md))
+
+*   cannot be null
+
+#### childrenv2 Type
+
+`string` ([Child passengers. Add a child and specify the age (must be from 2 to 15).](calendarmonthview-properties-child-passengers-add-a-child-and-specify-the-age-must-be-from-2-to-15.md))
+
+#### childrenv2 Constraints
+
+**unknown format**: the value of this string must follow the format: `delimited-ages`
+
+### infants
+
+Number of infant passengers. An infant is 1 year old or younger.
+
+`infants`
+
+*   is optional
+
+*   Type: `integer` ([Infant passengers. An infant is 1 year old or younger.](calendarmonthview-properties-infant-passengers-an-infant-is-1-year-old-or-younger.md))
+
+*   cannot be null
+
+#### infants Type
+
+`integer` ([Infant passengers. An infant is 1 year old or younger.](calendarmonthview-properties-infant-passengers-an-infant-is-1-year-old-or-younger.md))
+
+### rtn
+
+Trip type: 0 if oneway or 1 if return or multicity trip
+
+`rtn`
+
+*   is optional
+
+*   Type: `string` ([Trip type](calendarmonthview-properties-trip-type.md))
+
+*   cannot be null
+
+#### rtn Type
+
+`string` ([Trip type](calendarmonthview-properties-trip-type.md))
+
+#### rtn Constraints
+
+**enum**: the value of this property must be equal to one of the following values:
+
+| Value | Explanation |
+| :---- | :---------- |
+| `"0"` |             |
+| `"1"` |             |
 
 ### preferDirects
 
@@ -172,29 +200,112 @@ Will search only for direct flights if the value is true
 
 `preferDirects`
 
-- is optional
-- type: `boolean`
-- defined in this schema
+*   is optional
+
+*   Type: `boolean` ([Direct flights preferred](calendarmonthview-properties-direct-flights-preferred.md))
+
+*   cannot be null
 
 #### preferDirects Type
 
-`boolean`
+`boolean` ([Direct flights preferred](calendarmonthview-properties-direct-flights-preferred.md))
 
-### rtn
+### selectedoday
 
-Trip type: 0 if oneway or 1 if return trip
+Preselected outbound day of the month.
 
-`rtn`
+`selectedoday`
 
-- is optional
-- type: `enum`
-- defined in this schema
+*   is optional
 
-The value of this property **must** be equal to one of the [known values below](#rtn-known-values).
+*   Type: `string` ([Preselected outbound day of the month.](calendarmonthview-properties-preselected-outbound-day-of-the-month.md))
 
-#### rtn Known Values
+*   cannot be null
 
-| Value | Description |
-| ----- | ----------- |
-| `0`   |             |
-| `1`   |             |
+#### selectedoday Type
+
+`string` ([Preselected outbound day of the month.](calendarmonthview-properties-preselected-outbound-day-of-the-month.md))
+
+#### selectedoday Constraints
+
+**unknown format**: the value of this string must follow the format: `selected-date`
+
+### selectediday
+
+Preselected inbound day of the month.
+
+`selectediday`
+
+*   is optional
+
+*   Type: `string` ([Preselected inbound day of the month.](calendarmonthview-properties-preselected-inbound-day-of-the-month.md))
+
+*   cannot be null
+
+#### selectediday Type
+
+`string` ([Preselected inbound day of the month.](calendarmonthview-properties-preselected-inbound-day-of-the-month.md))
+
+#### selectediday Constraints
+
+**unknown format**: the value of this string must follow the format: `selected-date`
+
+### market
+
+The market of the user. Examples: UK, US, ES
+
+`market`
+
+*   is optional
+
+*   Type: `string` ([Market](calendarmonthview-properties-market.md))
+
+*   cannot be null
+
+#### market Type
+
+`string` ([Market](calendarmonthview-properties-market.md))
+
+#### market Constraints
+
+**unknown format**: the value of this string must follow the format: `market`
+
+### locale
+
+The desired locale for the page. Examples: es-ES, en-GB, ru-RU
+
+`locale`
+
+*   is optional
+
+*   Type: `string` ([Locale](calendarmonthview-properties-locale.md))
+
+*   cannot be null
+
+#### locale Type
+
+`string` ([Locale](calendarmonthview-properties-locale.md))
+
+#### locale Constraints
+
+**unknown format**: the value of this string must follow the format: `locale`
+
+### currency
+
+The desired currency for the page. Examples: GBP, EUR, USD
+
+`currency`
+
+*   is optional
+
+*   Type: `string` ([Currency](calendarmonthview-properties-currency.md))
+
+*   cannot be null
+
+#### currency Type
+
+`string` ([Currency](calendarmonthview-properties-currency.md))
+
+#### currency Constraints
+
+**unknown format**: the value of this string must follow the format: `currency`

--- a/source/includes/_flights_cheapFlightsTo.md.erb
+++ b/source/includes/_flights_cheapFlightsTo.md.erb
@@ -1,31 +1,27 @@
-## Cheap Flights To supported parameters Schema
+## Cheap Flights To View Schema
 
-```
+```txt
 /flights/cheap-flights-to
 ```
 
-| Property                    | Type     | Required     | Nullable | Defined by                                          |
-| --------------------------- | -------- | ------------ | -------- | --------------------------------------------------- |
-| [currency](#currency)       | `string` | Optional     | No       | Cheap Flights To supported parameters (this schema) |
-| [destination](#destination) | `string` | **Required** | No       | Cheap Flights To supported parameters (this schema) |
-| [locale](#locale)           | `string` | Optional     | No       | Cheap Flights To supported parameters (this schema) |
-| [market](#market)           | `string` | Optional     | No       | Cheap Flights To supported parameters (this schema) |
-| `*`                         | any      | Additional   | Yes      | this schema _allows_ additional properties          |
+A schema definition for the cheap flights to microsite supported parameters
 
-### currency
+| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions |
+| :------------------ | :--------- | :------------- | :----------- | :---------------- | :-------------------- | :------------------ |
+| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                |
 
-The desired currency for the page. Examples: GBP, EUR, USD  
-Please try to avoid using `locale`, `market` and `currency`, as these values will be governed by Skyscanner market detection logic on the Skyscanner site. If you believe you need to use these, please discuss with your account manager.
+### Cheap Flights To View Type
 
-`currency`
+`object` ([Cheap Flights To View](cheapflightsto.md))
 
-- is optional
-- type: `string`
-- defined in this schema
+## Cheap Flights To View Properties
 
-#### currency Type
-
-`string`
+| Property                    | Type     | Required | Nullable       |
+| :-------------------------- | :------- | :------- | :------------- |
+| [destination](#destination) | `string` | Required | cannot be null |
+| [market](#market)           | `string` | Optional | cannot be null |
+| [locale](#locale)           | `string` | Optional | cannot be null |
+| [currency](#currency)       | `string` | Optional | cannot be null |
 
 ### destination
 
@@ -33,40 +29,76 @@ Location code for the destination
 
 `destination`
 
-- is **required**
-- type: `string`
-- defined in this schema
+*   is required
+
+*   Type: `string` ([Destination](cheapflightsto-properties-destination.md))
+
+*   cannot be null
 
 #### destination Type
 
-`string`
+`string` ([Destination](cheapflightsto-properties-destination.md))
 
-### locale
+#### destination Constraints
 
-The desired locale for the page. Examples: es-ES, en-GB, ru-RU  
-Please try to avoid using `locale`, `market` and `currency`, as these values will be governed by Skyscanner market detection logic on the Skyscanner site. If you believe you need to use these, please discuss with your account manager.
-
-`locale`
-
-- is optional
-- type: `string`
-- defined in this schema
-
-#### locale Type
-
-`string`
+**unknown format**: the value of this string must follow the format: `place`
 
 ### market
 
-The market of the user. Examples: UK, US, ES  
-Please try to avoid using `locale`, `market` and `currency`, as these values will be governed by Skyscanner market detection logic on the Skyscanner site. If you believe you need to use these, please discuss with your account manager.
+The market of the user. Examples: UK, US, ES
 
 `market`
 
-- is optional
-- type: `string`
-- defined in this schema
+*   is optional
+
+*   Type: `string` ([Market](cheapflightsto-properties-market.md))
+
+*   cannot be null
 
 #### market Type
 
-`string`
+`string` ([Market](cheapflightsto-properties-market.md))
+
+#### market Constraints
+
+**unknown format**: the value of this string must follow the format: `market`
+
+### locale
+
+The desired locale for the page. Examples: es-ES, en-GB, ru-RU
+
+`locale`
+
+*   is optional
+
+*   Type: `string` ([Locale](cheapflightsto-properties-locale.md))
+
+*   cannot be null
+
+#### locale Type
+
+`string` ([Locale](cheapflightsto-properties-locale.md))
+
+#### locale Constraints
+
+**unknown format**: the value of this string must follow the format: `locale`
+
+### currency
+
+The desired currency for the page. Examples: GBP, EUR, USD
+
+`currency`
+
+*   is optional
+
+*   Type: `string` ([Currency](cheapflightsto-properties-currency.md))
+
+*   cannot be null
+
+#### currency Type
+
+`string` ([Currency](cheapflightsto-properties-currency.md))
+
+#### currency Constraints
+
+**unknown format**: the value of this string must follow the format: `currency`

--- a/source/includes/_flights_dayView.md.erb
+++ b/source/includes/_flights_dayView.md.erb
@@ -1,293 +1,46 @@
-## Flights Day View supported parameters Schema
+## Flights Day View Schema
 
-```
+```txt
 /flights/day-view
 ```
 
 A schema definition for the flights day-view microsite supported parameters
 
-| Abstract            | Extensible | Status       | Identifiable | Custom Properties | Additional Properties | Defined In                   |
-| ------------------- | ---------- | ------------ | ------------ | ----------------- | --------------------- | ---------------------------- |
-| Can be instantiated | No         | Experimental | No           | Forbidden         | Permitted             |  |
-
-## Flights Day View supported parameters Properties
-
-For more details, please see our [Examples](#examples) 
-
-| Property                                            | Type       | Required     | Nullable | Default                                    | Defined by                                          |
-| --------------------------------------------------- | ---------- | ------------ | -------- | ------------------------------------------ | --------------------------------------------------- |
-| [adultsv2](#adultsv2)                               | `integer`  | **Required** | No       | `1`                                        | Flights Day View supported parameters (this schema) |
-| [airlines](#airlines)                               | `string`   | Optional     | No       |                                            | Flights Day View supported parameters (this schema) |
-| [alliances](#alliances)                             | `string`   | Optional     | No       |                                            | Flights Day View supported parameters (this schema) |
-| [alternativedestinations](#alternativedestinations) | `string[]` | Optional     | No       |                                            | Flights Day View supported parameters (this schema) |
-| [alternativeorigins](#alternativeorigins)           | `string[]` | Optional     | No       |                                            | Flights Day View supported parameters (this schema) |
-| [cabinclass](#cabinclass)                           | `enum`     | **Required** | No       | `"economy"`                                | Flights Day View supported parameters (this schema) |
-| [childrenv2](#childrenv2)                           | `string`   | Optional     | No       |                                            | Flights Day View supported parameters (this schema) |
-| [currency](#currency)                               | `string`   | Optional     | No       |                                            | Flights Day View supported parameters (this schema) |
-| [departure-times](#departure-times)                 | `string`   | Optional     | No       |                                            | Flights Day View supported parameters (this schema) |
-| [destination](#destination)                         | `string`   | **Required** | No       |                                            | Flights Day View supported parameters (this schema) |
-| [duration](#duration)                               | `integer`  | Optional     | No       |                                            | Flights Day View supported parameters (this schema) |
-| [inboundDate](#inbounddate)                         | `string`   | Optional     | No       |                                            | Flights Day View supported parameters (this schema) |
-| [inboundaltsenabled](#inboundaltsenabled)           | `boolean`  | Optional     | No       |                                            | Flights Day View supported parameters (this schema) |
-| [infants](#infants)                                 | `integer`  | Optional     | No       |                                            | Flights Day View supported parameters (this schema) |
-| [locale](#locale)                                   | `string`   | Optional     | No       |                                            | Flights Day View supported parameters (this schema) |
-| [market](#market)                                   | `string`   | Optional     | No       |                                            | Flights Day View supported parameters (this schema) |
-| [origin](#origin)                                   | `string`   | **Required** | No       |                                            | Flights Day View supported parameters (this schema) |
-| [outboundDate](#outbounddate)                       | `string`   | **Required** | No       |                                            | Flights Day View supported parameters (this schema) |
-| [outboundaltsenabled](#outboundaltsenabled)         | `boolean`  | Optional     | No       |                                            | Flights Day View supported parameters (this schema) |
-| [preferDirects](#preferdirects)                     | `boolean`  | Optional     | No       |                                            | Flights Day View supported parameters (this schema) |
-| [showDirectDays](#showdirectdays)                   | `boolean`  | Optional     | No       | `true`                                     | Flights Day View supported parameters (this schema) |
-| [rtn](#rtn)                                         | `enum`     | Optional     | No       |                                            | Flights Day View supported parameters (this schema) |
-| [sortby](#sortby)                                   | `enum`     | Optional     | No       |                                            | Flights Day View supported parameters (this schema) |
-| `*`                                                 | any        | Additional   | Yes      | this schema _allows_ additional properties |
-
-### adultsv2
-
-Number of adult passengers. Adults have to be 16 years old or older.
-
-`adultsv2`
-
-- is **required**
-- type: `integer`
-- default: `1`
-- defined in this schema
-
-#### adultsv2 Type
-
-`integer`
-
-- minimum value: `1`
-
-### airlines
-
-A list of comma-separated IATA carrier codes to be passed to the dayview filters. For example: &airlines=AA,KL,LH. To
-unselect airline from the filters, the code must be specified with an exclamation mark. For example: &airlines=AA,!KL,!LH  
-You can search for IATA airline codes at the IATA website [here](https://www.iata.org/publications/pages/code-search.aspx)
-
-`airlines`
-
-- is optional
-- type: `string`
-- defined in this schema
-
-#### airlines Type
-
-`string`
-
-### alliances
-
-A comma-separated list of alliance names passed to the dayview filters. For example: &alliances=oneworld,Star%20Alliance
-
-`alliances`
-
-- is optional
-- type: `string`
-- defined in this schema
-
-#### alliances Type
-
-`string`
-
-### alternativedestinations
-
-An array of location codes which will be used as alternative destinations
-
-`alternativedestinations`
-
-- is optional
-- type: `string[]`
-- defined in this schema
-
-#### alternativedestinations Type
-
-Array type: `string[]`
-
-All items must be of the type: `string`
-
-### alternativeorigins
-
-An array of location codes which will be used as alternative origins
-
-`alternativeorigins`
-
-- is optional
-- type: `string[]`
-- defined in this schema
-
-#### alternativeorigins Type
-
-Array type: `string[]`
-
-All items must be of the type: `string`
-
-### cabinclass
-
-Cabin class for the flight, possible values are: `economy`, `premiumeconomy`, `business` and `first`
-
-`cabinclass`
-
-- is **required**
-- type: `enum`
-- default: `"economy"`
-- defined in this schema
-
-The value of this property **must** be equal to one of the [known values below](#cabinclass-known-values).
-
-#### cabinclass Known Values
-
-| Value            | Description |
-| ---------------- | ----------- |
-| `economy`        |             |
-| `premiumeconomy` |             |
-| `business`       |             |
-| `first`          |             |
-
-### childrenv2
-
-Number of child passengers. The value must be in the format integer|integer.. where each number is the age of the child
-passenger
-
-`childrenv2`
-
-- is optional
-- type: `string`
-- defined in this schema
-
-#### childrenv2 Type
-
-`string`
-
-### currency
-
-The desired currency for the page. Examples: GBP, EUR, USD  
-Please try to avoid using `locale`, `market` and `currency`, as these values will be governed by Skyscanner market detection logic on the Skyscanner site. If you believe you need to use these, please discuss with your account manager.
-
-The desired currency for the page. Examples: GBP, EUR, USD
-
-`currency`
-
-- is optional
-- type: `string`
-- defined in this schema
-
-#### currency Type
-
-`string`
-
-### departure-times
-
-Sets the dayview departure time filters in minutes. For example: &departure-times=00-90,30-990 (first leg departs
-between 00 and 1:30 and second leg departs between 00:30 and 16:30).
-
-`departure-times`
-
-- is optional
-- type: `string`
-- defined in this schema
-
-#### departure-times Type
-
-`string`
-
-### destination
-
-Location code for the destination
-
-`destination`
-
-- is **required**
-- type: `string`
-- defined in this schema
-
-#### destination Type
-
-`string`
-
-### duration
-
-Sets the dayview duration filters in minutes. For example: &duration=1320 (22 hours)
-
-`duration`
-
-- is optional
-- type: `integer`
-- defined in this schema
-
-#### duration Type
-
-`integer`
-
-### inboundDate
-
-Inbound date in the format YYYY-MM-DD
-
-`inboundDate`
-
-- is optional
-- type: `string`
-- defined in this schema
-
-#### inboundDate Type
-
-`string`
-
-### inboundaltsenabled
-
-Including nearby airports as an inbound place
-
-`inboundaltsenabled`
-
-- is optional
-- type: `boolean`
-- defined in this schema
-
-#### inboundaltsenabled Type
-
-`boolean`
-
-### infants
-
-Number of infant passengers. An infant is 1 year old or younger.
-
-`infants`
-
-- is optional
-- type: `integer`
-- defined in this schema
-
-#### infants Type
-
-`integer`
-
-### locale
-
-The desired locale for the page. Examples: es-ES, en-GB, ru-RU  
-Please try to avoid using `locale`, `market` and `currency`, as these values will be governed by Skyscanner market detection logic on the Skyscanner site. If you believe you need to use these, please discuss with your account manager.
-
-`locale`
-
-- is optional
-- type: `string`
-- defined in this schema
-
-#### locale Type
-
-`string`
-
-### market
-
-The market of the user. Examples: UK, US, ES
-Please try to avoid using `locale`, `market` and `currency`, as these values will be governed by Skyscanner market detection logic on the Skyscanner site. If you believe you need to use these, please discuss with your account manager.
-
-`market`
-
-- is optional
-- type: `string`
-- defined in this schema
-
-#### market Type
-
-`string`
+| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions |
+| :------------------ | :--------- | :------------- | :----------- | :---------------- | :-------------------- | :------------------ |
+| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                |
+
+### Flights Day View Type
+
+`object` ([Flights Day View](dayview.md))
+
+## Flights Day View Properties
+
+| Property                                            | Type      | Required | Nullable       |
+| :-------------------------------------------------- | :-------- | :------- | :------------- |
+| [origin](#origin)                                   | `string`  | Required | cannot be null |
+| [destination](#destination)                         | `string`  | Required | cannot be null |
+| [outboundDate](#outbounddate)                       | `string`  | Required | cannot be null |
+| [inboundDate](#inbounddate)                         | `string`  | Optional | cannot be null |
+| [adultsv2](#adultsv2)                               | `integer` | Required | cannot be null |
+| [childrenv2](#childrenv2)                           | `string`  | Optional | cannot be null |
+| [infants](#infants)                                 | `integer` | Optional | cannot be null |
+| [cabinclass](#cabinclass)                           | `string`  | Required | cannot be null |
+| [rtn](#rtn)                                         | `string`  | Optional | cannot be null |
+| [preferDirects](#preferdirects)                     | `boolean` | Optional | cannot be null |
+| [showDirectDays](#showdirectdays)                   | `boolean` | Optional | cannot be null |
+| [outboundaltsenabled](#outboundaltsenabled)         | `boolean` | Optional | cannot be null |
+| [inboundaltsenabled](#inboundaltsenabled)           | `boolean` | Optional | cannot be null |
+| [alternativeorigins](#alternativeorigins)           | `array`   | Optional | cannot be null |
+| [alternativedestinations](#alternativedestinations) | `array`   | Optional | cannot be null |
+| [market](#market)                                   | `string`  | Optional | cannot be null |
+| [locale](#locale)                                   | `string`  | Optional | cannot be null |
+| [currency](#currency)                               | `string`  | Optional | cannot be null |
+| [sortby](#sortby)                                   | `string`  | Optional | cannot be null |
+| [airlines](#airlines)                               | `string`  | Optional | cannot be null |
+| [alliances](#alliances)                             | `string`  | Optional | cannot be null |
+| [departure-times](#departure-times)                 | `string`  | Optional | cannot be null |
+| [duration](#duration)                               | `integer` | Optional | cannot be null |
 
 ### origin
 
@@ -295,13 +48,39 @@ Location code for the origin
 
 `origin`
 
-- is **required**
-- type: `string`
-- defined in this schema
+*   is required
+
+*   Type: `string` ([Origin](dayview-properties-origin.md))
+
+*   cannot be null
 
 #### origin Type
 
-`string`
+`string` ([Origin](dayview-properties-origin.md))
+
+#### origin Constraints
+
+**unknown format**: the value of this string must follow the format: `place`
+
+### destination
+
+Location code for the destination
+
+`destination`
+
+*   is required
+
+*   Type: `string` ([Destination](dayview-properties-destination.md))
+
+*   cannot be null
+
+#### destination Type
+
+`string` ([Destination](dayview-properties-destination.md))
+
+#### destination Constraints
+
+**unknown format**: the value of this string must follow the format: `place`
 
 ### outboundDate
 
@@ -309,55 +88,138 @@ Outbound date in the format YYYY-MM-DD
 
 `outboundDate`
 
-- is **required**
-- type: `string`
-- defined in this schema
+*   is required
+
+*   Type: `string` ([Outbound Date](dayview-properties-outbound-date.md))
+
+*   cannot be null
 
 #### outboundDate Type
 
-`string`
+`string` ([Outbound Date](dayview-properties-outbound-date.md))
 
-### outboundaltsenabled
+#### outboundDate Constraints
 
-Including nearby airports as an outbound place
+**unknown format**: the value of this string must follow the format: `date-yymmdd`
 
-`outboundaltsenabled`
+### inboundDate
 
-- is optional
-- type: `boolean`
-- defined in this schema
+Inbound date in the format YYYY-MM-DD
 
-#### outboundaltsenabled Type
+`inboundDate`
 
-`boolean`
+*   is optional
 
-### preferDirects
+*   Type: `string` ([Inbound Date](dayview-properties-inbound-date.md))
 
-Will search only for direct flights if the value is true
+*   cannot be null
 
-`preferDirects`
+#### inboundDate Type
 
-- is optional
-- type: `boolean`
-- defined in this schema
+`string` ([Inbound Date](dayview-properties-inbound-date.md))
 
-#### preferDirects Type
+#### inboundDate Constraints
 
-`boolean`
+**unknown format**: the value of this string must follow the format: `date-yymmdd`
 
-### showDirectDays
+### adultsv2
 
-Controls the visibility of the day view screen, which presents the user with options for different dates with direct flights, when there are no direct flights for the currently selected dates.
+Number of adult passengers. Adults have to be 16 years old or older.
 
-`showDirectDays`
+`adultsv2`
 
-- is optional
-- type: `boolean`
-- defined in this schema
+*   is required
 
-#### showDirectDays Type
+*   Type: `integer` ([Adult passengers. Adults have to be 16 years old or older.](dayview-properties-adult-passengers-adults-have-to-be-16-years-old-or-older.md))
 
-`boolean`
+*   cannot be null
+
+#### adultsv2 Type
+
+`integer` ([Adult passengers. Adults have to be 16 years old or older.](dayview-properties-adult-passengers-adults-have-to-be-16-years-old-or-older.md))
+
+#### adultsv2 Constraints
+
+**minimum**: the value of this number must greater than or equal to: `1`
+
+#### adultsv2 Default Value
+
+The default value is:
+
+```json
+1
+```
+
+### childrenv2
+
+Number of child passengers. The value must be in the format integer|integer.. where each number is the age of the child passenger
+
+`childrenv2`
+
+*   is optional
+
+*   Type: `string` ([Child passengers. Add a child and specify the age (must be from 2 to 15).](dayview-properties-child-passengers-add-a-child-and-specify-the-age-must-be-from-2-to-15.md))
+
+*   cannot be null
+
+#### childrenv2 Type
+
+`string` ([Child passengers. Add a child and specify the age (must be from 2 to 15).](dayview-properties-child-passengers-add-a-child-and-specify-the-age-must-be-from-2-to-15.md))
+
+#### childrenv2 Constraints
+
+**unknown format**: the value of this string must follow the format: `delimited-ages`
+
+### infants
+
+Number of infant passengers. An infant is 1 year old or younger.
+
+`infants`
+
+*   is optional
+
+*   Type: `integer` ([Infant passengers. An infant is 1 year old or younger.](dayview-properties-infant-passengers-an-infant-is-1-year-old-or-younger.md))
+
+*   cannot be null
+
+#### infants Type
+
+`integer` ([Infant passengers. An infant is 1 year old or younger.](dayview-properties-infant-passengers-an-infant-is-1-year-old-or-younger.md))
+
+### cabinclass
+
+Cabin class for the flight, possible values are: economy, premiumeconomy, business and first
+
+`cabinclass`
+
+*   is required
+
+*   Type: `string` ([Cabin Class](dayview-properties-cabin-class.md))
+
+*   cannot be null
+
+#### cabinclass Type
+
+`string` ([Cabin Class](dayview-properties-cabin-class.md))
+
+#### cabinclass Constraints
+
+**enum**: the value of this property must be equal to one of the following values:
+
+| Value              | Explanation |
+| :----------------- | :---------- |
+| `"economy"`        |             |
+| `"premiumeconomy"` |             |
+| `"business"`       |             |
+| `"first"`          |             |
+
+#### cabinclass Default Value
+
+The default value is:
+
+```json
+"economy"
+```
 
 ### rtn
 
@@ -365,18 +227,188 @@ Trip type: 0 if oneway or 1 if return or multicity trip
 
 `rtn`
 
-- is optional
-- type: `enum`
-- defined in this schema
+*   is optional
 
-The value of this property **must** be equal to one of the [known values below](#rtn-known-values).
+*   Type: `string` ([Trip Type](dayview-properties-trip-type.md))
 
-#### rtn Known Values
+*   cannot be null
 
-| Value | Description |
-| ----- | ----------- |
-| `0`   |             |
-| `1`   |             |
+#### rtn Type
+
+`string` ([Trip Type](dayview-properties-trip-type.md))
+
+#### rtn Constraints
+
+**enum**: the value of this property must be equal to one of the following values:
+
+| Value | Explanation |
+| :---- | :---------- |
+| `"0"` |             |
+| `"1"` |             |
+
+### preferDirects
+
+Will search only for direct flights if the value is true
+
+`preferDirects`
+
+*   is optional
+
+*   Type: `boolean` ([Direct Flights Preferred](dayview-properties-direct-flights-preferred.md))
+
+*   cannot be null
+
+#### preferDirects Type
+
+`boolean` ([Direct Flights Preferred](dayview-properties-direct-flights-preferred.md))
+
+### showDirectDays
+
+Show days with direct flights
+
+`showDirectDays`
+
+*   is optional
+
+*   Type: `boolean` ([Show days with direct flights](dayview-properties-show-days-with-direct-flights.md))
+
+*   cannot be null
+
+#### showDirectDays Type
+
+`boolean` ([Show days with direct flights](dayview-properties-show-days-with-direct-flights.md))
+
+#### showDirectDays Default Value
+
+The default value is:
+
+```json
+true
+```
+
+### outboundaltsenabled
+
+Including nearby airports as an outbound place
+
+`outboundaltsenabled`
+
+*   is optional
+
+*   Type: `boolean` ([Including nearby airports as an outbound place](dayview-properties-including-nearby-airports-as-an-outbound-place.md))
+
+*   cannot be null
+
+#### outboundaltsenabled Type
+
+`boolean` ([Including nearby airports as an outbound place](dayview-properties-including-nearby-airports-as-an-outbound-place.md))
+
+### inboundaltsenabled
+
+Including nearby airports as an inbound place
+
+`inboundaltsenabled`
+
+*   is optional
+
+*   Type: `boolean` ([Including nearby airports as an inbound place](dayview-properties-including-nearby-airports-as-an-inbound-place.md))
+
+*   cannot be null
+
+#### inboundaltsenabled Type
+
+`boolean` ([Including nearby airports as an inbound place](dayview-properties-including-nearby-airports-as-an-inbound-place.md))
+
+### alternativeorigins
+
+An array of location codes which will be used as alternative origins
+
+`alternativeorigins`
+
+*   is optional
+
+*   Type: `string[]`
+
+*   cannot be null
+
+#### alternativeorigins Type
+
+`string[]`
+
+### alternativedestinations
+
+An array of location codes which will be used as alternative destinations
+
+`alternativedestinations`
+
+*   is optional
+
+*   Type: `string[]`
+
+*   cannot be null
+
+#### alternativedestinations Type
+
+`string[]`
+
+### market
+
+The market of the user. Examples: UK, US, ES
+
+`market`
+
+*   is optional
+
+*   Type: `string` ([Market](dayview-properties-market.md))
+
+*   cannot be null
+
+#### market Type
+
+`string` ([Market](dayview-properties-market.md))
+
+#### market Constraints
+
+**unknown format**: the value of this string must follow the format: `market`
+
+### locale
+
+The desired locale for the page. Examples: es-ES, en-GB, ru-RU
+
+`locale`
+
+*   is optional
+
+*   Type: `string` ([Locale](dayview-properties-locale.md))
+
+*   cannot be null
+
+#### locale Type
+
+`string` ([Locale](dayview-properties-locale.md))
+
+#### locale Constraints
+
+**unknown format**: the value of this string must follow the format: `locale`
+
+### currency
+
+The desired currency for the page. Examples: GBP, EUR, USD
+
+`currency`
+
+*   is optional
+
+*   Type: `string` ([Currency](dayview-properties-currency.md))
+
+*   cannot be null
+
+#### currency Type
+
+`string` ([Currency](dayview-properties-currency.md))
+
+#### currency Constraints
+
+**unknown format**: the value of this string must follow the format: `currency`
 
 ### sortby
 
@@ -384,16 +416,98 @@ Sets the sorting order for the results. Possible values are: best, cheapest and 
 
 `sortby`
 
-- is optional
-- type: `enum`
-- defined in this schema
+*   is optional
 
-The value of this property **must** be equal to one of the [known values below](#sortby-known-values).
+*   Type: `string` ([Sorting](dayview-properties-sorting.md))
 
-#### sortby Known Values
+*   cannot be null
 
-| Value      | Description |
-| ---------- | ----------- |
-| `best`     |             |
-| `cheapest` |             |
-| `fastest`  |             |
+#### sortby Type
+
+`string` ([Sorting](dayview-properties-sorting.md))
+
+#### sortby Constraints
+
+**enum**: the value of this property must be equal to one of the following values:
+
+| Value        | Explanation |
+| :----------- | :---------- |
+| `"best"`     |             |
+| `"cheapest"` |             |
+| `"fastest"`  |             |
+
+### airlines
+
+List of comma separated IATA carrier codes to be passed to the dayview filters. For example: \&airlines=AA,KL,LH. To unselect airline from the filters, the code must be specified with exclamation mark. For example: \&airlines=AA,!KL,!LH
+
+`airlines`
+
+*   is optional
+
+*   Type: `string` ([Sets the dayview airlines filters.](dayview-properties-sets-the-dayview-airlines-filters.md))
+
+*   cannot be null
+
+#### airlines Type
+
+`string` ([Sets the dayview airlines filters.](dayview-properties-sets-the-dayview-airlines-filters.md))
+
+#### airlines Constraints
+
+**unknown format**: the value of this string must follow the format: `airlines`
+
+### alliances
+
+Comma separated list of alliance names passed to the dayview filters. For example: \&alliances=OneWorld,Star%20Alliance. Valid values are 'OneWorld', 'Star Alliance', 'SkyTeam' and 'Value Alliance'
+
+`alliances`
+
+*   is optional
+
+*   Type: `string` ([Sets the dayview alliances filters.](dayview-properties-sets-the-dayview-alliances-filters.md))
+
+*   cannot be null
+
+#### alliances Type
+
+`string` ([Sets the dayview alliances filters.](dayview-properties-sets-the-dayview-alliances-filters.md))
+
+#### alliances Constraints
+
+**unknown format**: the value of this string must follow the format: `alliances`
+
+### departure-times
+
+Sets the dayview departure time filters in minutes. For example: \&departure-times=00-90,30-990 (first leg departs between 00 and 1:30 and second leg departs between 00:30 and 16:30).
+
+`departure-times`
+
+*   is optional
+
+*   Type: `string` ([Sets the dayview departure time filters.](dayview-properties-sets-the-dayview-departure-time-filters.md))
+
+*   cannot be null
+
+#### departure-times Type
+
+`string` ([Sets the dayview departure time filters.](dayview-properties-sets-the-dayview-departure-time-filters.md))
+
+#### departure-times Constraints
+
+**unknown format**: the value of this string must follow the format: `departure-times`
+
+### duration
+
+Sets the dayview duration filters in minutes. For example: \&duration=1320 (22 hours)
+
+`duration`
+
+*   is optional
+
+*   Type: `integer` ([Sets the dayview duration filters.](dayview-properties-sets-the-dayview-duration-filters.md))
+
+*   cannot be null
+
+#### duration Type
+
+`integer` ([Sets the dayview duration filters.](dayview-properties-sets-the-dayview-duration-filters.md))

--- a/source/includes/_flights_homeView.md.erb
+++ b/source/includes/_flights_homeView.md.erb
@@ -1,15 +1,66 @@
-## Flights Home Page supported parameters Schema
+## Flights Home Page Schema
 
-```
+```txt
 /flights/home
 ```
 
-| Property              | Type     | Required   | Nullable | Defined by                                           |
-| --------------------- | -------- | ---------- | -------- | ---------------------------------------------------- |
-| [currency](#currency) | `string` | Optional   | No       | Flights Home Page supported parameters (this schema) |
-| [locale](#locale)     | `string` | Optional   | No       | Flights Home Page supported parameters (this schema) |
-| [market](#market)     | `string` | Optional   | No       | Flights Home Page supported parameters (this schema) |
-| `*`                   | any      | Additional | Yes      | this schema _allows_ additional properties           |
+A schema definition for the flights home page microsite supported parameters
+
+| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions |
+| :------------------ | :--------- | :------------- | :----------- | :---------------- | :-------------------- | :------------------ |
+| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                |
+
+### Flights Home Page Type
+
+`object` ([Flights Home Page](flightshomepage.md))
+
+## Flights Home Page Properties
+
+| Property              | Type     | Required | Nullable       |
+| :-------------------- | :------- | :------- | :------------- |
+| [market](#market)     | `string` | Optional | cannot be null |
+| [locale](#locale)     | `string` | Optional | cannot be null |
+| [currency](#currency) | `string` | Optional | cannot be null |
+
+### market
+
+The market of the user. Examples: UK, US, ES
+
+`market`
+
+*   is optional
+
+*   Type: `string` ([Market](flightshomepage-properties-market.md))
+
+*   cannot be null
+
+#### market Type
+
+`string` ([Market](flightshomepage-properties-market.md))
+
+#### market Constraints
+
+**unknown format**: the value of this string must follow the format: `market`
+
+### locale
+
+The desired locale for the page. Examples: es-ES, en-GB, ru-RU
+
+`locale`
+
+*   is optional
+
+*   Type: `string` ([Locale](flightshomepage-properties-locale.md))
+
+*   cannot be null
+
+#### locale Type
+
+`string` ([Locale](flightshomepage-properties-locale.md))
+
+#### locale Constraints
+
+**unknown format**: the value of this string must follow the format: `locale`
 
 ### currency
 
@@ -17,40 +68,16 @@ The desired currency for the page. Examples: GBP, EUR, USD
 
 `currency`
 
-- is optional
-- type: `string`
-- defined in this schema
+*   is optional
+
+*   Type: `string` ([Currency](flightshomepage-properties-currency.md))
+
+*   cannot be null
 
 #### currency Type
 
-`string`
+`string` ([Currency](flightshomepage-properties-currency.md))
 
-### locale
+#### currency Constraints
 
-The desired locale for the page. Examples: es-ES, en-GB, ru-RU  
-Please try to avoid using `locale`, `market` and `currency`, as these values will be governed by Skyscanner market detection logic on the Skyscanner site. If you believe you need to use these, please discuss with your account manager.
-
-`locale`
-
-- is optional
-- type: `string`
-- defined in this schema
-
-#### locale Type
-
-`string`
-
-### market
-
-The market of the user. Examples: UK, US, ES  
-Please try to avoid using `locale`, `market` and `currency`, as these values will be governed by Skyscanner market detection logic on the Skyscanner site. If you believe you need to use these, please discuss with your account manager.
-
-`market`
-
-- is optional
-- type: `string`
-- defined in this schema
-
-#### market Type
-
-`string`
+**unknown format**: the value of this string must follow the format: `currency`

--- a/source/includes/_flights_multiCity.md.erb
+++ b/source/includes/_flights_multiCity.md.erb
@@ -1,318 +1,48 @@
 ## Flights Day View for multicity search Schema
 
-```
+```txt
 /flights/multicity
 ```
 
-| Property                      | Type      | Required     | Nullable | Default                                    | Defined by                                          |
-| ----------------------------- | --------- | ------------ | -------- | ------------------------------------------ | --------------------------------------------------- |
-| [adultsv2](#adultsv2)         | `integer` | **Required** | No       | `1`                                        | Flights Day View for multicity search (this schema) |
-| [cabinclass](#cabinclass)     | `enum`    | **Required** | No       | `"economy"`                                | Flights Day View for multicity search (this schema) |
-| [childrenv2](#childrenv2)     | `string`  | Optional     | No       |                                            | Flights Day View for multicity search (this schema) |
-| [currency](#currency)         | `string`  | Optional     | No       |                                            | Flights Day View for multicity search (this schema) |
-| [date0](#date0)               | `string`  | **Required** | No       |                                            | Flights Day View for multicity search (this schema) |
-| [date1](#date1)               | `string`  | Optional     | No       |                                            | Flights Day View for multicity search (this schema) |
-| [date2](#date2)               | `string`  | Optional     | No       |                                            | Flights Day View for multicity search (this schema) |
-| [date3](#date3)               | `string`  | Optional     | No       |                                            | Flights Day View for multicity search (this schema) |
-| [date4](#date4)               | `string`  | Optional     | No       |                                            | Flights Day View for multicity search (this schema) |
-| [date5](#date5)               | `string`  | Optional     | No       |                                            | Flights Day View for multicity search (this schema) |
-| [destination0](#destination0) | `string`  | **Required** | No       |                                            | Flights Day View for multicity search (this schema) |
-| [destination1](#destination1) | `string`  | Optional     | No       |                                            | Flights Day View for multicity search (this schema) |
-| [destination2](#destination2) | `string`  | Optional     | No       |                                            | Flights Day View for multicity search (this schema) |
-| [destination3](#destination3) | `string`  | Optional     | No       |                                            | Flights Day View for multicity search (this schema) |
-| [destination4](#destination4) | `string`  | Optional     | No       |                                            | Flights Day View for multicity search (this schema) |
-| [destination5](#destination5) | `string`  | Optional     | No       |                                            | Flights Day View for multicity search (this schema) |
-| [infants](#infants)           | `integer` | Optional     | No       |                                            | Flights Day View for multicity search (this schema) |
-| [locale](#locale)             | `string`  | Optional     | No       |                                            | Flights Day View for multicity search (this schema) |
-| [market](#market)             | `string`  | Optional     | No       |                                            | Flights Day View for multicity search (this schema) |
-| [origin0](#origin0)           | `string`  | **Required** | No       |                                            | Flights Day View for multicity search (this schema) |
-| [origin1](#origin1)           | `string`  | Optional     | No       |                                            | Flights Day View for multicity search (this schema) |
-| [origin2](#origin2)           | `string`  | Optional     | No       |                                            | Flights Day View for multicity search (this schema) |
-| [origin3](#origin3)           | `string`  | Optional     | No       |                                            | Flights Day View for multicity search (this schema) |
-| [origin4](#origin4)           | `string`  | Optional     | No       |                                            | Flights Day View for multicity search (this schema) |
-| [origin5](#origin5)           | `string`  | Optional     | No       |                                            | Flights Day View for multicity search (this schema) |
-| `*`                           | any       | Additional   | Yes      | this schema _allows_ additional properties |
-
-### adultsv2
-
-Number of adult passengers. Adults have to be 16 years old or older.
-
-`adultsv2`
-
-- is **required**
-- type: `integer`
-- default: `1`
-- defined in this schema
-
-#### adultsv2 Type
-
-`integer`
-
-- minimum value: `1`
-
-### cabinclass
-
-Cabin class for the flight, possible values are: economy, premiumeconomy, business and first
-
-`cabinclass`
-
-- is **required**
-- type: `enum`
-- default: `"economy"`
-- defined in this schema
-
-The value of this property **must** be equal to one of the [known values below](#cabinclass-known-values).
-
-#### cabinclass Known Values
-
-| Value            | Description |
-| ---------------- | ----------- |
-| `economy`        |             |
-| `premiumeconomy` |             |
-| `business`       |             |
-| `first`          |             |
-
-### childrenv2
-
-Number of child passengers. The value must be in the format integer|integer.. where each number is the age of the child
-passenger
-
-`childrenv2`
-
-- is optional
-- type: `string`
-- defined in this schema
-
-#### childrenv2 Type
-
-`string`
-
-### currency
-
-The desired currency for the page. Examples: GBP, EUR, USD  
-Please try to avoid using `locale`, `market` and `currency`, as these values will be governed by Skyscanner market detection logic on the Skyscanner site. If you believe you need to use these, please discuss with your account manager.
-
-`currency`
-
-- is optional
-- type: `string`
-- defined in this schema
-
-#### currency Type
-
-`string`
-
-### date0
-
-Outbound date of the first flight in the format YYYY-MM-DD
-
-`date0`
-
-- is **required**
-- type: `string`
-- defined in this schema
-
-#### date0 Type
-
-`string`
-
-### date1
-
-Outbound date of the second flight in the format YYYY-MM-DD
-
-`date1`
-
-- is optional
-- type: `string`
-- defined in this schema
-
-#### date1 Type
-
-`string`
-
-### date2
-
-Outbound date of the third flight in the format YYYY-MM-DD
-
-`date2`
-
-- is optional
-- type: `string`
-- defined in this schema
-
-#### date2 Type
-
-`string`
-
-### date3
-
-Outbound date of the fourth flight in the format YYYY-MM-DD
-
-`date3`
-
-- is optional
-- type: `string`
-- defined in this schema
-
-#### date3 Type
-
-`string`
-
-### date4
-
-Outbound date of the fifth flight in the format YYYY-MM-DD
-
-`date4`
-
-- is optional
-- type: `string`
-- defined in this schema
-
-#### date4 Type
-
-`string`
-
-### date5
-
-Outbound date of the sixth flight in the format YYYY-MM-DD
-
-`date5`
-
-- is optional
-- type: `string`
-- defined in this schema
-
-#### date5 Type
-
-`string`
-
-### destination0
-
-Location code for the destination of the first flight
-
-`destination0`
-
-- is **required**
-- type: `string`
-- defined in this schema
-
-#### destination0 Type
-
-`string`
-
-### destination1
-
-Location code for the destination of the second flight
-
-`destination1`
-
-- is optional
-- type: `string`
-- defined in this schema
-
-#### destination1 Type
-
-`string`
-
-### destination2
-
-Location code for the destination of the third flight
-
-`destination2`
-
-- is optional
-- type: `string`
-- defined in this schema
-
-#### destination2 Type
-
-`string`
-
-### destination3
-
-Location code for the destination of the fourth flight
-
-`destination3`
-
-- is optional
-- type: `string`
-- defined in this schema
-
-#### destination3 Type
-
-`string`
-
-### destination4
-
-Location code for the destination of the fifth flight
-
-`destination4`
-
-- is optional
-- type: `string`
-- defined in this schema
-
-#### destination4 Type
-
-`string`
-
-### destination5
-
-Location code for the destination of the sixth flight
-
-`destination5`
-
-- is optional
-- type: `string`
-- defined in this schema
-
-#### destination5 Type
-
-`string`
-
-### infants
-
-Number of infant passengers. An infant is 1 year old or younger.
-
-`infants`
-
-- is optional
-- type: `integer`
-- defined in this schema
-
-#### infants Type
-
-`integer`
-
-### locale
-
-The desired locale for the page. Examples: es-ES, en-GB, ru-RU  
-Please try to avoid using `locale`, `market` and `currency`, as these values will be governed by Skyscanner market detection logic on the Skyscanner site. If you believe you need to use these, please discuss with your account manager.
-
-`locale`
-
-- is optional
-- type: `string`
-- defined in this schema
-
-#### locale Type
-
-`string`
-
-### market
-
-The market of the user. Examples: UK, US, ES  
-Please try to avoid using `locale`, `market` and `currency`, as these values will be governed by Skyscanner market detection logic on the Skyscanner site. If you believe you need to use these, please discuss with your account manager.
-
-`market`
-
-- is optional
-- type: `string`
-- defined in this schema
-
-#### market Type
-
-`string`
+A schema definition for the flights day-view microsite supported query parameters
+
+| Abstract            | Extensible | Status         | Identifiable | Custom Properties | Additional Properties | Access Restrictions |
+| :------------------ | :--------- | :------------- | :----------- | :---------------- | :-------------------- | :------------------ |
+| Can be instantiated | No         | Unknown status | No           | Forbidden         | Allowed               | none                |
+
+### Flights Day View for multicity search Type
+
+`object` ([Flights Day View for multicity search](multicity.md))
+
+## Flights Day View for multicity search Properties
+
+| Property                      | Type      | Required | Nullable       |
+| :---------------------------- | :-------- | :------- | :------------- |
+| [origin0](#origin0)           | `string`  | Required | cannot be null |
+| [date0](#date0)               | `string`  | Required | cannot be null |
+| [destination0](#destination0) | `string`  | Required | cannot be null |
+| [origin1](#origin1)           | `string`  | Optional | cannot be null |
+| [date1](#date1)               | `string`  | Optional | cannot be null |
+| [destination1](#destination1) | `string`  | Optional | cannot be null |
+| [origin2](#origin2)           | `string`  | Optional | cannot be null |
+| [date2](#date2)               | `string`  | Optional | cannot be null |
+| [destination2](#destination2) | `string`  | Optional | cannot be null |
+| [origin3](#origin3)           | `string`  | Optional | cannot be null |
+| [date3](#date3)               | `string`  | Optional | cannot be null |
+| [destination3](#destination3) | `string`  | Optional | cannot be null |
+| [origin4](#origin4)           | `string`  | Optional | cannot be null |
+| [date4](#date4)               | `string`  | Optional | cannot be null |
+| [destination4](#destination4) | `string`  | Optional | cannot be null |
+| [origin5](#origin5)           | `string`  | Optional | cannot be null |
+| [date5](#date5)               | `string`  | Optional | cannot be null |
+| [destination5](#destination5) | `string`  | Optional | cannot be null |
+| [adultsv2](#adultsv2)         | `integer` | Required | cannot be null |
+| [childrenv2](#childrenv2)     | `string`  | Optional | cannot be null |
+| [infants](#infants)           | `integer` | Optional | cannot be null |
+| [cabinclass](#cabinclass)     | `string`  | Required | cannot be null |
+| [market](#market)             | `string`  | Optional | cannot be null |
+| [locale](#locale)             | `string`  | Optional | cannot be null |
+| [currency](#currency)         | `string`  | Optional | cannot be null |
 
 ### origin0
 
@@ -320,13 +50,59 @@ Location code for the origin of the first flight
 
 `origin0`
 
-- is **required**
-- type: `string`
-- defined in this schema
+*   is required
+
+*   Type: `string` ([First flight origin](multicity-properties-first-flight-origin.md))
+
+*   cannot be null
 
 #### origin0 Type
 
-`string`
+`string` ([First flight origin](multicity-properties-first-flight-origin.md))
+
+#### origin0 Constraints
+
+**unknown format**: the value of this string must follow the format: `place`
+
+### date0
+
+Outbound date of the first flight in the format YYYY-MM-DD
+
+`date0`
+
+*   is required
+
+*   Type: `string` ([Outbound Date of the first flight](multicity-properties-outbound-date-of-the-first-flight.md))
+
+*   cannot be null
+
+#### date0 Type
+
+`string` ([Outbound Date of the first flight](multicity-properties-outbound-date-of-the-first-flight.md))
+
+#### date0 Constraints
+
+**unknown format**: the value of this string must follow the format: `date-yyyy-mm-dd`
+
+### destination0
+
+Location code for the destination of the first flight
+
+`destination0`
+
+*   is required
+
+*   Type: `string` ([First flight destination](multicity-properties-first-flight-destination.md))
+
+*   cannot be null
+
+#### destination0 Type
+
+`string` ([First flight destination](multicity-properties-first-flight-destination.md))
+
+#### destination0 Constraints
+
+**unknown format**: the value of this string must follow the format: `place`
 
 ### origin1
 
@@ -334,13 +110,59 @@ Location code for the origin of the second flight
 
 `origin1`
 
-- is optional
-- type: `string`
-- defined in this schema
+*   is optional
+
+*   Type: `string` ([Second flight origin](multicity-properties-second-flight-origin.md))
+
+*   cannot be null
 
 #### origin1 Type
 
-`string`
+`string` ([Second flight origin](multicity-properties-second-flight-origin.md))
+
+#### origin1 Constraints
+
+**unknown format**: the value of this string must follow the format: `place`
+
+### date1
+
+Outbound date of the second flight in the format YYYY-MM-DD
+
+`date1`
+
+*   is optional
+
+*   Type: `string` ([Outbound Date of the second flight](multicity-properties-outbound-date-of-the-second-flight.md))
+
+*   cannot be null
+
+#### date1 Type
+
+`string` ([Outbound Date of the second flight](multicity-properties-outbound-date-of-the-second-flight.md))
+
+#### date1 Constraints
+
+**unknown format**: the value of this string must follow the format: `date-yyyy-mm-dd`
+
+### destination1
+
+Location code for the destination of the second flight
+
+`destination1`
+
+*   is optional
+
+*   Type: `string` ([Second flight destination](multicity-properties-second-flight-destination.md))
+
+*   cannot be null
+
+#### destination1 Type
+
+`string` ([Second flight destination](multicity-properties-second-flight-destination.md))
+
+#### destination1 Constraints
+
+**unknown format**: the value of this string must follow the format: `place`
 
 ### origin2
 
@@ -348,13 +170,59 @@ Location code for the origin of the third flight
 
 `origin2`
 
-- is optional
-- type: `string`
-- defined in this schema
+*   is optional
+
+*   Type: `string` ([Third flight origin](multicity-properties-third-flight-origin.md))
+
+*   cannot be null
 
 #### origin2 Type
 
-`string`
+`string` ([Third flight origin](multicity-properties-third-flight-origin.md))
+
+#### origin2 Constraints
+
+**unknown format**: the value of this string must follow the format: `place`
+
+### date2
+
+Outbound date of the third flight in the format YYYY-MM-DD
+
+`date2`
+
+*   is optional
+
+*   Type: `string` ([Outbound Date of the third flight](multicity-properties-outbound-date-of-the-third-flight.md))
+
+*   cannot be null
+
+#### date2 Type
+
+`string` ([Outbound Date of the third flight](multicity-properties-outbound-date-of-the-third-flight.md))
+
+#### date2 Constraints
+
+**unknown format**: the value of this string must follow the format: `date-yyyy-mm-dd`
+
+### destination2
+
+Location code for the destination of the third flight
+
+`destination2`
+
+*   is optional
+
+*   Type: `string` ([Third flight destination](multicity-properties-third-flight-destination.md))
+
+*   cannot be null
+
+#### destination2 Type
+
+`string` ([Third flight destination](multicity-properties-third-flight-destination.md))
+
+#### destination2 Constraints
+
+**unknown format**: the value of this string must follow the format: `place`
 
 ### origin3
 
@@ -362,13 +230,59 @@ Location code for the origin of the fourth flight
 
 `origin3`
 
-- is optional
-- type: `string`
-- defined in this schema
+*   is optional
+
+*   Type: `string` ([Fourth flight origin](multicity-properties-fourth-flight-origin.md))
+
+*   cannot be null
 
 #### origin3 Type
 
-`string`
+`string` ([Fourth flight origin](multicity-properties-fourth-flight-origin.md))
+
+#### origin3 Constraints
+
+**unknown format**: the value of this string must follow the format: `place`
+
+### date3
+
+Outbound date of the fourth flight in the format YYYY-MM-DD
+
+`date3`
+
+*   is optional
+
+*   Type: `string` ([Outbound Date of the fourth flight](multicity-properties-outbound-date-of-the-fourth-flight.md))
+
+*   cannot be null
+
+#### date3 Type
+
+`string` ([Outbound Date of the fourth flight](multicity-properties-outbound-date-of-the-fourth-flight.md))
+
+#### date3 Constraints
+
+**unknown format**: the value of this string must follow the format: `date-yyyy-mm-dd`
+
+### destination3
+
+Location code for the destination of the fourth flight
+
+`destination3`
+
+*   is optional
+
+*   Type: `string` ([Fourth flight destination](multicity-properties-fourth-flight-destination.md))
+
+*   cannot be null
+
+#### destination3 Type
+
+`string` ([Fourth flight destination](multicity-properties-fourth-flight-destination.md))
+
+#### destination3 Constraints
+
+**unknown format**: the value of this string must follow the format: `place`
 
 ### origin4
 
@@ -376,13 +290,59 @@ Location code for the origin of the fifth flight
 
 `origin4`
 
-- is optional
-- type: `string`
-- defined in this schema
+*   is optional
+
+*   Type: `string` ([Fifth flight origin](multicity-properties-fifth-flight-origin.md))
+
+*   cannot be null
 
 #### origin4 Type
 
-`string`
+`string` ([Fifth flight origin](multicity-properties-fifth-flight-origin.md))
+
+#### origin4 Constraints
+
+**unknown format**: the value of this string must follow the format: `place`
+
+### date4
+
+Outbound date of the fifth flight in the format YYYY-MM-DD
+
+`date4`
+
+*   is optional
+
+*   Type: `string` ([Outbound Date of the fifth flight.](multicity-properties-outbound-date-of-the-fifth-flight.md))
+
+*   cannot be null
+
+#### date4 Type
+
+`string` ([Outbound Date of the fifth flight.](multicity-properties-outbound-date-of-the-fifth-flight.md))
+
+#### date4 Constraints
+
+**unknown format**: the value of this string must follow the format: `date-yyyy-mm-dd`
+
+### destination4
+
+Location code for the destination of the fifth flight
+
+`destination4`
+
+*   is optional
+
+*   Type: `string` ([Fifth flight destination](multicity-properties-fifth-flight-destination.md))
+
+*   cannot be null
+
+#### destination4 Type
+
+`string` ([Fifth flight destination](multicity-properties-fifth-flight-destination.md))
+
+#### destination4 Constraints
+
+**unknown format**: the value of this string must follow the format: `place`
 
 ### origin5
 
@@ -390,10 +350,215 @@ Location code for the origin of the sixth flight
 
 `origin5`
 
-- is optional
-- type: `string`
-- defined in this schema
+*   is optional
+
+*   Type: `string` ([Sixth flight origin](multicity-properties-sixth-flight-origin.md))
+
+*   cannot be null
 
 #### origin5 Type
 
-`string`
+`string` ([Sixth flight origin](multicity-properties-sixth-flight-origin.md))
+
+#### origin5 Constraints
+
+**unknown format**: the value of this string must follow the format: `place`
+
+### date5
+
+Outbound date of the sixth flight in the format YYYY-MM-DD
+
+`date5`
+
+*   is optional
+
+*   Type: `string` ([Outbound Date of the sixth flight](multicity-properties-outbound-date-of-the-sixth-flight.md))
+
+*   cannot be null
+
+#### date5 Type
+
+`string` ([Outbound Date of the sixth flight](multicity-properties-outbound-date-of-the-sixth-flight.md))
+
+#### date5 Constraints
+
+**unknown format**: the value of this string must follow the format: `date-yyyy-mm-dd`
+
+### destination5
+
+Location code for the destination of the sixth flight
+
+`destination5`
+
+*   is optional
+
+*   Type: `string` ([Sixth flight destination](multicity-properties-sixth-flight-destination.md))
+
+*   cannot be null
+
+#### destination5 Type
+
+`string` ([Sixth flight destination](multicity-properties-sixth-flight-destination.md))
+
+#### destination5 Constraints
+
+**unknown format**: the value of this string must follow the format: `place`
+
+### adultsv2
+
+Number of adult passengers. Adults have to be 16 years old or older.
+
+`adultsv2`
+
+*   is required
+
+*   Type: `integer` ([Adult passengers. Adults have to be 16 years old or older.](multicity-properties-adult-passengers-adults-have-to-be-16-years-old-or-older.md))
+
+*   cannot be null
+
+#### adultsv2 Type
+
+`integer` ([Adult passengers. Adults have to be 16 years old or older.](multicity-properties-adult-passengers-adults-have-to-be-16-years-old-or-older.md))
+
+#### adultsv2 Constraints
+
+**minimum**: the value of this number must greater than or equal to: `1`
+
+#### adultsv2 Default Value
+
+The default value is:
+
+```json
+1
+```
+
+### childrenv2
+
+Number of child passengers. The value must be in the format integer|integer.. where each number is the age of the child passenger
+
+`childrenv2`
+
+*   is optional
+
+*   Type: `string` ([Child passengers. Add a child and specify the age (must be from 2 to 15).](multicity-properties-child-passengers-add-a-child-and-specify-the-age-must-be-from-2-to-15.md))
+
+*   cannot be null
+
+#### childrenv2 Type
+
+`string` ([Child passengers. Add a child and specify the age (must be from 2 to 15).](multicity-properties-child-passengers-add-a-child-and-specify-the-age-must-be-from-2-to-15.md))
+
+#### childrenv2 Constraints
+
+**unknown format**: the value of this string must follow the format: `delimited-ages`
+
+### infants
+
+Number of infant passengers. An infant is 1 year old or younger.
+
+`infants`
+
+*   is optional
+
+*   Type: `integer` ([Infant passengers. An infant is 1 year old or younger.](multicity-properties-infant-passengers-an-infant-is-1-year-old-or-younger.md))
+
+*   cannot be null
+
+#### infants Type
+
+`integer` ([Infant passengers. An infant is 1 year old or younger.](multicity-properties-infant-passengers-an-infant-is-1-year-old-or-younger.md))
+
+### cabinclass
+
+Cabin class for the flight, possible values are: economy, premiumeconomy, business and first
+
+`cabinclass`
+
+*   is required
+
+*   Type: `string` ([Cabin Class](multicity-properties-cabin-class.md))
+
+*   cannot be null
+
+#### cabinclass Type
+
+`string` ([Cabin Class](multicity-properties-cabin-class.md))
+
+#### cabinclass Constraints
+
+**enum**: the value of this property must be equal to one of the following values:
+
+| Value              | Explanation |
+| :----------------- | :---------- |
+| `"economy"`        |             |
+| `"premiumeconomy"` |             |
+| `"business"`       |             |
+| `"first"`          |             |
+
+#### cabinclass Default Value
+
+The default value is:
+
+```json
+"economy"
+```
+
+### market
+
+The market of the user. Examples: UK, US, ES
+
+`market`
+
+*   is optional
+
+*   Type: `string` ([Market](multicity-properties-market.md))
+
+*   cannot be null
+
+#### market Type
+
+`string` ([Market](multicity-properties-market.md))
+
+#### market Constraints
+
+**unknown format**: the value of this string must follow the format: `market`
+
+### locale
+
+The desired locale for the page. Examples: es-ES, en-GB, ru-RU
+
+`locale`
+
+*   is optional
+
+*   Type: `string` ([Locale](multicity-properties-locale.md))
+
+*   cannot be null
+
+#### locale Type
+
+`string` ([Locale](multicity-properties-locale.md))
+
+#### locale Constraints
+
+**unknown format**: the value of this string must follow the format: `locale`
+
+### currency
+
+The desired currency for the page. Examples: GBP, EUR, USD
+
+`currency`
+
+*   is optional
+
+*   Type: `string` ([Currency](multicity-properties-currency.md))
+
+*   cannot be null
+
+#### currency Type
+
+`string` ([Currency](multicity-properties-currency.md))
+
+#### currency Constraints
+
+**unknown format**: the value of this string must follow the format: `currency`

--- a/source/includes/_referrals.md.erb
+++ b/source/includes/_referrals.md.erb
@@ -1,9 +1,10 @@
 # Referrals
 
-The referral service is used to provide partner redirects
-to Skyscanner pages based on provided request parameters. 
-It can redirect to different pages within Skyscanner based on the provided {pagetype} parameter 
-(for the full list of page types and examples see below).
+The referral service is used to provide partner redirects to Skyscanner pages based on provided
+request parameters.
+
+It can redirect to different pages within Skyscanner based on the provided {pagetype} parameter.
+For the full list of page types and examples see the sections below.
 
 *API endpoint*
 
@@ -11,24 +12,31 @@ The API is accessible at **https://skyscanner.net/g/referrals/v1**
 
 There is one main endpoint with the following URL structure:
 
-`https://skyscanner.net/g/referrals/v1/{vertical}/{pagetype}?associateid={associateId}`
+`https://skyscanner.net/g/referrals/v1/{vertical}/{pagetype}`
 
 The endpoint serves only GET requests and responds with HTTP status 301 redirecting to the desired Skyscanner page.
 
 For the different possible values of the parameters and additional query parameters check the tables below.
 
+We use [Impact](https://impact.com/) to track the redirects and associate them with the referral source.
+You will need to include the 3 Impact tracking parameters as query parameters in your requests. Please
+check the `TRACKING QUERY PARAMETERS` section below for more details on the parameters. Although the
+parameters are optional, the redirects will not be correctly tracked without them.
+
+If you already have your tracking integration using the legacy `associateid` parameter, we will still
+support this and map the legacy parameter to the new Impact parameters automatically. However, we discourage
+using it for new referral links, as it will become fully deprecated eventually.
+
 *TRY IT OUT*
 
-[![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/84b89b3a51c23e6230d7)
+[![Run in Postman](https://run.pstmn.io/button.svg)](https://god.gw.postman.com/run-collection/18538161-5f231ad5-0a03-4d55-a5c7-843974ab85d7?action=collection%2Ffork&collection-url=entityId%3D18538161-5f231ad5-0a03-4d55-a5c7-843974ab85d7%26entityType%3Dcollection%26workspaceId%3D8e0f947f-e0b9-4761-86da-2a878f98110b)
 
 *REQUEST PARAMETERS*
 
 | Parameter | Description |
 | --------- | ------- |
 | ```vertical``` <br><span class="required">REQUIRED</span> | The vertical you want to redirect to. Allowed values: flights, cars|
-| ```pagetype``` <br><span class="required">OPTIONAL</span> | Page type supported by each vertical. E.g. for flights -> day-view, browse-view... take a look at the next table|
-| ```associateid``` <br><span class="required">OPTIONAL</span> | Associate partner id to attribute traffic to|
-| ```utm_term``` <br><span class="required">OPTIONAL</span> | Used to send through a unique variable that you can track back to your campaigns.|
+| ```pagetype``` <br><span class="required">REQUIRED</span> | Page type supported by each vertical. E.g. for flights -> day-view, browse-view... take a look at the next table|
 
 *PAGE TYPES*
 
@@ -37,34 +45,43 @@ For the different possible values of the parameters and additional query paramet
 | flights | home, day-view, calendar-month-view, browse-view, multicity, cheap-flights-to, flights-airline |
 | cars | home, day-view |
 
+*TRACKING QUERY PARAMETERS*
+
+| Parameter | Description |
+| --------- | ------- |
+| ```mediaPartnerId``` <br><span class="required">OPTIONAL</span> | The ID associated with the partner in Impact |
+| ```adId``` <br><span class="required">OPTIONAL</span> | The ID associated with the ad type in Impact |
+| ```campaignId``` <br><span class="required">OPTIONAL</span> | The ID associated with the campaign in Impact |
+| ```utm_term``` <br><span class="required">OPTIONAL</span> | Used to send through a unique variable that you can track back to your campaigns.|
+
 ## Examples
 
 An example including some of the parameters looks like:
 
 Please try to avoid using `locale`, `market` and `currency`, as these values will be governed by Skyscanner market detection logic on the Skyscanner site. If you believe you need to use these, please discuss with your account manager.
 
-`GET https://skyscanner.net/g/referrals/v1/flights/day-view/?origin=cdg&destination=edi&outboundDate=2019-10-14&utm_term=summer&associateid=MY_ID_123`
+`GET https://skyscanner.net/g/referrals/v1/flights/day-view/?origin=cdg&destination=edi&outboundDate=<%= config[:fullenddate] %>&utm_term=summer&mediaPartnerId=2796596&campaignId=13416&adId=1100662`
 
-`GET https://skyscanner.net/g/referrals/v1/flights/calendar-month-view/?origin=cdg&destination=edi&iym=1910&utm_term=summer&associateid=MY_ID_123`
+`GET https://skyscanner.net/g/referrals/v1/flights/calendar-month-view/?origin=cdg&destination=edi&iym=1910&utm_term=summer&mediaPartnerId=2796596&campaignId=13416&adId=1100662`
 
-`GET https://skyscanner.net/g/referrals/v1/cars/day-view/?pickupPlace=BCN&dropoffPlace=BCN&pickupTime=2019-09-10T10:00&dropoffTime=2019-09-15T10:00&driverAge=42&associateid=MY_ID_123`
+`GET https://skyscanner.net/g/referrals/v1/cars/day-view/?pickupPlace=BCN&dropoffPlace=BCN&pickupTime=<%= config[:fullstartdate] %>T10:00&dropoffTime=<%= config[:fullenddate] %>T10:00&driverAge=42&mediaPartnerId=2796596&campaignId=13416&adId=1100662`
 
-Preferred airlines:  
+Preferred airlines:
 You can find IATA airline codes [here](https://www.iata.org/publications/pages/code-search.aspx)
 
-`GET https://skyscanner.net/g/referrals/v1/flights/day-view?airlines=AA,!FB&market=UK&currency=GBP&locale=en-GB&origin=cdg&destination=edi&outboundDate=2020-10-14&inboundDate=2020-10-21`
+`GET https://skyscanner.net/g/referrals/v1/flights/day-view?airlines=AA,!FB&market=UK&currency=GBP&locale=en-GB&origin=cdg&destination=edi&outboundDate=<%= config[:fullstartdate] %>&inboundDate=<%= config[:fullenddate] %>`
 
 Preferred alliances:
 
-`GET https://skyscanner.net/g/referrals/v1/flights/day-view?alliances=oneworld,Star%20Alliance&market=UK&currency=GBP&locale=en-GB&origin=cdg&destination=edi&outboundDate=2020-10-14&inboundDate=2020-10-21`
+`GET https://skyscanner.net/g/referrals/v1/flights/day-view?alliances=oneworld,Star%20Alliance&market=UK&currency=GBP&locale=en-GB&origin=cdg&destination=edi&outboundDate=<%= config[:fullstartdate] %>&inboundDate=<%= config[:fullenddate] %>`
 
 Departure times - in this example, the query parameter configures the filters to have the first leg's departure time as default (-), and the second leg between 0 (00:00) and 990 minutes (16:30).
 
-`GET https://skyscanner.net/g/referrals/v1/flights/day-view?departure-times=-%7C0-990&market=UK&currency=GBP&locale=en-GB&origin=cdg&destination=edi&outboundDate=2020-10-14&inboundDate=2020-10-21`
+`GET https://skyscanner.net/g/referrals/v1/flights/day-view?departure-times=-%7C0-990&market=UK&currency=GBP&locale=en-GB&origin=cdg&destination=edi&outboundDate=<%= config[:fullstartdate] %>&inboundDate=<%= config[:fullenddate] %>`
 
 Duration:
 
-`GET https://skyscanner.net/g/referrals/v1/flights/day-view?duration=1320&market=UK&currency=GBP&locale=en-GB&origin=cdg&destination=edi&outboundDate=2020-10-14&inboundDate=2020-10-21`
+`GET https://skyscanner.net/g/referrals/v1/flights/day-view?duration=1320&market=UK&currency=GBP&locale=en-GB&origin=cdg&destination=edi&outboundDate=<%= config[:fullstartdate] %>&inboundDate=<%= config[:fullenddate] %>`
 
 
 Specific request query parameters are provided in the tables below.
@@ -84,15 +101,15 @@ Please refer to our <a href="#response-codes">response codes</a> in case of unsu
 
 | Page type | Description  |
 | --- | ---|
+| [home](#flights-home-page-supported-parameters-schema) | Skyscanner's Home [Example Link](https://www.skyscanner.net/)|
 | [day-view](#flights-day-view-supported-parameters-schema) | Flights Day View [Example Link](https://www.skyscanner.net/transport/flights/sof/ams/<%= config[:startdate] %>/<%= config[:enddate] %>/?adults=1&children=2&adultsv2=1&childrenv2=3%7c2&infants=0&cabinclass=economy&rtn=1&preferdirects=false&outboundaltsenabled=false&inboundaltsenabled=false&ref=home#/)|
 | [calendar-month-view](#flights-calendar-month-view-supported-parameters-schema) | Flights MonthView [Example Link](https://www.skyscanner.net/transport/flights/sof/ams/?adults=1&children=2&adultsv2=1&childrenv2=3%7C2&infants=0&cabinclass=economy&rtn=1&preferdirects=false&outboundaltsenabled=false&inboundaltsenabled=false&oym=<%= config[:startmonth] %>&iym=<%= config[:endmonth] %>&ref=home&selectedoday=01&selectediday=01)|
 | [browse-view](#flights-browse-view-supported-parameters-schema) | Flights BrowseView [Example Link](https://www.skyscanner.net/transport/flights-from/edi/?adults=1&children=2&adultsv2=1&childrenv2=3%7c2&infants=0&cabinclass=economy&rtn=1&preferdirects=false&outboundaltsenabled=false&inboundaltsenabled=false&oym=<%= config[:startmonth] %>&iym=<%= config[:endmonth] %>&ref=home)|
 | [multicity](#flights-day-view-for-multicity-search-schema) | Flights Multicity [Example Link](https://www.skyscanner.net/transport/d/sof/<%= config[:fullstartdate] %>/ams/ams/<%= config[:fullenddate] %>/lond/lond/<%= config[:fullenddate] %>/sof?adults=1&children=2&adultsv2=1&childrenv2=3%7c2&infants=0&cabinclass=economy&ref=home#/)|
-| [home](#flights-home-page-supported-parameters-schema) | Skyscanner's Home [Example Link](https://www.skyscanner.net/)|
 | [cheap-flights-to](#cheap-flights-to-supported-parameters-schema) | Cheap Flights To [Example Link](https://www.skyscanner.net/za/en-gb/zar/flights-to/bom/cheap-flights-to-mumbai-airport.html)|
 | [flights-airline](#flights-airline-supported-parameters-schema) | Flights Airline [Example Link](https://www.skyscanner.net/airline/airline-emirates-ek.html)|
 
-For more details, please see our [Examples](#examples) 
+For more details, please see our [Examples](#examples)
 
 ## Cars Parameters
 
@@ -100,5 +117,5 @@ For more details, please see our [Examples](#examples)
 
 | API endpoint | Description  |
 | --- | ---|
-| [day-view](#carhire-day-view-supported-parameters-schema) | CarHire DayView [Example Link](https://www.skyscanner.net/carhire/results/95565041/95565041/<%= config[:fullstartdate] %>T10:00/<%= config[:fullenddate] %>T10:00/30)|
 | [home](#carhire-home-page-supported-parameters-schema) | CarHire Home [Example Link](https://www.skyscanner.net/carhire) |
+| [day-view](#carhire-day-view-supported-parameters-schema) | CarHire DayView [Example Link](https://www.skyscanner.net/carhire/results/95565041/95565041/<%= config[:fullstartdate] %>T10:00/<%= config[:fullenddate] %>T10:00/30)|

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -4,7 +4,7 @@ title: API Reference
 toc_footers:
   - <a href='https://partners.skyscanner.net/contact/' target="_blank">Request API key</a>
   - <a href='https://support.business.skyscanner.net/hc/en-us' target="_blank">Find answers in our FAQ</a>
-  - <a href='https://stackoverflow.com/search?q=skyscanner+api' target="_blank">Ask on Stack Overflow</a> 
+  - <a href='https://stackoverflow.com/search?q=skyscanner+api' target="_blank">Ask on Stack Overflow</a>
   - <a href='https://medium.com/@SkyscannerEng' target="_blank">Follow the Skyscanner Engineering blog</a>
   - <a href='https://partners.skyscanner.net/log-in/'>Sign in to your account</a>
   - <a href='http://www.skyscanner.net/jobs/' target="_blank">Join the team!</a>
@@ -23,15 +23,15 @@ includes:
   - places
   - redirects
   - referrals
+  - flights_homeView
   - flights_dayView
   - flights_browseView
   - flights_calendarMonthView
   - flights_multiCity
-  - flights_homeView
   - flights_cheapFlightsTo
   - flights_airline
-  - cars_dayView
   - cars_carsHome
+  - cars_dayView
   - response_codes
   - HTTPS_migration_guide
 search: false


### PR DESCRIPTION
# Context

The Referrals section of the documentation is outdated:

* It still references the legacy `associateid` parameter as the correct way to set-up tracking
* The API schemas haven't been updated since 2019
* The examples in the documentation use dates in the past (which don't work)

# Changes

* Comment out the hotels schema generation (since we don't support it anymore)
* Change the generation script to output `.md.erb` instead of `.md` files
* Regenerate the API schemas for the referrals sub sections
* Update the referrals main section:
  * Replace the references to `associateid` with the new Impact tracking parameters
  * Replace the hardcoded dates in the example links with dynamic ones
  * Add a section explaining the Impact integration
  * Re-create the Postman collection using Impact parameters
* Change the order of the sub-sections under referrals

# Notes:

Most of the file changes are auto-generated. The auto-generated changes are in a separate commit so you can separate the changes this way, or alternatively, pay extra attention to `source/includes/_referrals.md.erb` which isn't.